### PR TITLE
fix: auto-update remo-spm README version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,12 @@ jobs:
           sed -i '' "s|checksum: \"[^\"]*\"|checksum: \"${CHECKSUM}\"|" \
               Package.swift
 
+          # Update README.md version references
+          sed -i '' "s|from: \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"|from: \"${VERSION}\"|g" \
+              README.md
+          sed -i '' "s|pod 'RemoSwift', '~> [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*'|pod 'RemoSwift', '~> ${VERSION}'|g" \
+              README.md
+
           # Sync Swift source
           cp "$GITHUB_WORKSPACE/swift/RemoSwift/Sources/RemoSwift/Remo.swift" \
              Sources/RemoSwift/Remo.swift


### PR DESCRIPTION
## Summary
- Add `sed` commands to `release.yml` that automatically update SPM (`from:`) and CocoaPods (`~>`) version references in the `remo-spm` README.md during each release.

## Test plan
- [ ] Verify next release (`v0.3.0+`) updates `remo-spm` README with correct version numbers.

Made with [Cursor](https://cursor.com)