### PR TITLE
feat: dynamic capability registration with unregister API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remo-bonjour"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "thiserror",
  "tokio",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "remo-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "remo-desktop"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "dashmap",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "remo-objc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "remo-protocol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "serde",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "remo-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dashmap",
  "futures",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "remo-transport"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "futures",
  "remo-protocol",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "remo-usbmuxd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "plist",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "remo-workspace"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "remo-desktop",
  "remo-protocol",

--- a/README.md
+++ b/README.md
@@ -86,6 +86,30 @@ Remo.register("myFeature.toggle") { params in
 }];
 ```
 
+Capabilities can be unregistered dynamically — useful for page-level or conditional capabilities:
+
+**Swift**
+
+```swift
+// Register when entering a screen
+Remo.register("detail.getInfo") { _ in ["item": itemName] }
+
+// Unregister when leaving
+Remo.unregister("detail.getInfo")
+```
+
+**Objective-C**
+
+```objc
+// Register
+[RMRemo registerCapability:@"detail.getInfo" handler:^NSDictionary *(NSDictionary *params) {
+    return @{@"item": self.itemName};
+}];
+
+// Unregister
+[RMRemo unregisterCapability:@"detail.getInfo"];
+```
+
 ### 3. Install the CLI
 
 ```bash

--- a/crates/remo-sdk/src/ffi.rs
+++ b/crates/remo-sdk/src/ffi.rs
@@ -200,6 +200,20 @@ pub unsafe extern "C" fn remo_register_capability(
     });
 }
 
+/// Unregister a capability by name.
+///
+/// Returns `true` if the capability existed and was removed, `false` otherwise.
+///
+/// # Safety
+/// `name` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn remo_unregister_capability(name: *const c_char) -> bool {
+    let name = CStr::from_ptr(name).to_string_lossy();
+    let g = global();
+    let lock = g.lock().unwrap();
+    lock.registry.unregister(&name)
+}
+
 /// Free a Rust-allocated C string.
 ///
 /// # Safety

--- a/crates/remo-sdk/src/registry.rs
+++ b/crates/remo-sdk/src/registry.rs
@@ -141,4 +141,21 @@ mod tests {
         names.sort();
         assert_eq!(names, vec!["a", "b"]);
     }
+
+    #[tokio::test]
+    async fn unregister_removes_capability() {
+        let reg = CapabilityRegistry::new();
+        reg.register_sync("temp", |_| Ok(serde_json::json!({"ok": true})));
+        assert!(reg.has("temp"));
+
+        assert!(reg.unregister("temp"));
+        assert!(!reg.has("temp"));
+        assert!(reg.invoke("temp", Value::Null).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn unregister_missing_returns_false() {
+        let reg = CapabilityRegistry::new();
+        assert!(!reg.unregister("nonexistent"));
+    }
 }

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,0 +1,93 @@
+# RemoExample
+
+A demo iOS app showcasing the Remo SDK — register capabilities, invoke them from the CLI, and verify the UI.
+
+## Run
+
+```bash
+# Option 1: Use published SDK (default)
+open RemoExample.xcworkspace
+
+# Option 2: Use local monorepo source (for SDK development)
+REMO_LOCAL=1 xcodebuild build -workspace RemoExample.xcworkspace -scheme RemoExample \
+  -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+Build and run `RemoExample` scheme on a simulator or device.
+
+## Capabilities
+
+The app registers capabilities at different scopes to demonstrate both global and page-level (dynamic) registration.
+
+### Global (always available)
+
+| Capability | Description | Example |
+|------------|-------------|---------|
+| `navigate` | Switch tab | `remo call navigate '{"route":"items"}'` |
+| `state.get` | Read state | `remo call state.get '{"key":"counter"}'` |
+| `state.set` | Write state | `remo call state.set '{"key":"username","value":"Alice"}'` |
+| `ui.toast` | Show toast | `remo call ui.toast '{"message":"Hello!"}'` |
+| `ui.confetti` | Trigger confetti | `remo call ui.confetti '{}'` |
+| `ui.setAccentColor` | Change theme | `remo call ui.setAccentColor '{"color":"purple"}'` |
+
+### Home tab (available when Home is visible)
+
+| Capability | Description | Example |
+|------------|-------------|---------|
+| `counter.increment` | Bump counter | `remo call counter.increment '{"amount":5}'` |
+
+### Items tab (available when Items is visible)
+
+| Capability | Description | Example |
+|------------|-------------|---------|
+| `items.add` | Add item | `remo call items.add '{"name":"New"}'` |
+| `items.remove` | Remove item | `remo call items.remove '{"name":"Item A"}'` |
+| `items.clear` | Clear all | `remo call items.clear '{}'` |
+
+### Detail page (available when viewing an item)
+
+| Capability | Description | Example |
+|------------|-------------|---------|
+| `detail.getInfo` | Get current item | `remo call detail.getInfo '{}'` |
+
+> Page-level capabilities are registered with `Remo.register` in `.task` and unregistered with `Remo.unregister` in `.onDisappear`. Use `remo list` to see which capabilities are currently active.
+
+## Try It
+
+```bash
+# 1. Discover the running app
+remo devices
+
+# 2. List currently available capabilities
+remo list -a <addr>
+
+# 3. Invoke a global capability
+remo call -a <addr> ui.toast '{"message":"Hello from CLI!"}'
+
+# 4. Navigate to Items tab, then list again — items.* capabilities appear
+remo call -a <addr> navigate '{"route":"items"}'
+remo list -a <addr>
+
+# 5. Navigate away — items.* capabilities disappear
+remo call -a <addr> navigate '{"route":"home"}'
+remo list -a <addr>
+
+# 6. Take a screenshot to verify
+remo screenshot -a <addr> -o screen.jpg
+```
+
+## Architecture
+
+```
+RemoExample.xcworkspace
+├── RemoExample/                  # App shell (entry point only)
+├── RemoExamplePackage/           # All feature code (SPM)
+│   └── Sources/RemoExampleFeature/
+│       └── ContentView.swift     # Views + capability registration
+├── Config/                       # XCConfig build settings
+└── RemoExampleUITests/           # UI automation tests
+```
+
+All capabilities are registered in `ContentView.swift`:
+- Global capabilities in `setupRemo()` (called once at app launch)
+- Page-level capabilities in each view's `.task` / `.onDisappear`

--- a/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/ContentView.swift
+++ b/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/ContentView.swift
@@ -57,6 +57,52 @@ public final class AppStore: @unchecked Sendable {
     }
 }
 
+// MARK: - Page-Level Capability Helpers
+
+/// Register page-level capabilities from a non-isolated context.
+/// Avoids Swift 6 MainActor isolation issues when Remo handlers
+/// are invoked from background threads.
+func registerHomeCapabilities(store: AppStore) {
+    Remo.register("counter.increment") { params in
+        let amount = params["amount"] as? Int ?? 1
+        DispatchQueue.main.async { store.counter += amount }
+        return ["status": "ok", "amount": amount]
+    }
+}
+
+func registerItemsCapabilities(store: AppStore) {
+    Remo.register("items.add") { params in
+        let name = params["name"] as? String ?? "New Item"
+        DispatchQueue.main.async {
+            withAnimation { store.items.append(name) }
+        }
+        return ["status": "ok", "name": name]
+    }
+    Remo.register("items.remove") { params in
+        let name = params["name"] as? String ?? ""
+        DispatchQueue.main.async {
+            withAnimation {
+                if let idx = store.items.firstIndex(of: name) {
+                    store.items.remove(at: idx)
+                }
+            }
+        }
+        return ["status": "ok", "name": name]
+    }
+    Remo.register("items.clear") { _ in
+        DispatchQueue.main.async {
+            withAnimation { store.items.removeAll() }
+        }
+        return ["status": "ok"]
+    }
+}
+
+func registerDetailCapabilities(item: String) {
+    Remo.register("detail.getInfo") { _ in
+        return ["item": item]
+    }
+}
+
 // MARK: - Remo Setup
 
 public func setupRemo(store: AppStore) {
@@ -111,12 +157,6 @@ public func setupRemo(store: AppStore) {
         return ["status": "ok"]
     }
 
-    logged("counter.increment") { params in
-        let amount = params["amount"] as? Int ?? 1
-        DispatchQueue.main.async { store.counter += amount }
-        return ["status": "ok", "amount": amount]
-    }
-
     // -- UI effect capabilities -----------------------------------------------
 
     logged("ui.toast") { params in
@@ -156,34 +196,6 @@ public func setupRemo(store: AppStore) {
         return ["status": "ok", "color": color]
     }
 
-    // -- List manipulation capabilities ---------------------------------------
-
-    logged("items.add") { params in
-        let name = params["name"] as? String ?? "New Item"
-        DispatchQueue.main.async {
-            withAnimation { store.items.append(name) }
-        }
-        return ["status": "ok", "name": name]
-    }
-
-    logged("items.remove") { params in
-        let name = params["name"] as? String ?? ""
-        DispatchQueue.main.async {
-            withAnimation {
-                if let idx = store.items.firstIndex(of: name) {
-                    store.items.remove(at: idx)
-                }
-            }
-        }
-        return ["status": "ok", "name": name]
-    }
-
-    logged("items.clear") { _ in
-        DispatchQueue.main.async {
-            withAnimation { store.items.removeAll() }
-        }
-        return ["status": "ok"]
-    }
 }
 
 // MARK: - Root View
@@ -279,6 +291,12 @@ struct HomeView: View {
             }
             .padding()
             .navigationTitle("Remo")
+            .task {
+                registerHomeCapabilities(store: store)
+            }
+            .onDisappear {
+                Remo.unregister("counter.increment")
+            }
         }
     }
 }
@@ -358,6 +376,14 @@ struct ListPage: View {
                     }
                 }
             }
+            .task {
+                registerItemsCapabilities(store: store)
+            }
+            .onDisappear {
+                Remo.unregister("items.add")
+                Remo.unregister("items.remove")
+                Remo.unregister("items.clear")
+            }
         }
     }
 }
@@ -376,6 +402,12 @@ struct DetailPage: View {
                 .foregroundStyle(.secondary)
         }
         .navigationTitle(item)
+        .task {
+            registerDetailCapabilities(item: item)
+        }
+        .onDisappear {
+            Remo.unregister("detail.getInfo")
+        }
     }
 }
 

--- a/swift/RemoSwift/Sources/RemoObjC/RMRemo.m
+++ b/swift/RemoSwift/Sources/RemoObjC/RMRemo.m
@@ -72,6 +72,10 @@ static dispatch_once_t _startOnce;
     remo_register_capability(name.UTF8String, context, RMRemoTrampoline);
 }
 
++ (BOOL)unregisterCapability:(NSString *)name {
+    return remo_unregister_capability(name.UTF8String);
+}
+
 + (NSArray<NSString *> *)listCapabilities {
     [self ensureStarted];
 
@@ -102,6 +106,7 @@ static dispatch_once_t _startOnce;
 + (void)start {}
 + (void)stop {}
 + (void)registerCapability:(NSString *)name handler:(RMRemoCapabilityHandler)handler {}
++ (BOOL)unregisterCapability:(NSString *)name { return NO; }
 + (NSArray<NSString *> *)listCapabilities { return @[]; }
 
 @end

--- a/swift/RemoSwift/Sources/RemoObjC/include/RMRemo.h
+++ b/swift/RemoSwift/Sources/RemoObjC/include/RMRemo.h
@@ -41,6 +41,10 @@ typedef NSDictionary<NSString *, id> *_Nonnull (^RMRemoCapabilityHandler)(NSDict
 /// Register a capability that can be invoked from macOS.
 + (void)registerCapability:(NSString *)name handler:(RMRemoCapabilityHandler)handler;
 
+/// Unregister a capability by name.
+/// Returns YES if the capability existed and was removed.
++ (BOOL)unregisterCapability:(NSString *)name;
+
 /// List all registered capability names.
 + (NSArray<NSString *> *)listCapabilities;
 

--- a/swift/RemoSwift/Sources/RemoSwift/Remo.swift
+++ b/swift/RemoSwift/Sources/RemoSwift/Remo.swift
@@ -72,6 +72,16 @@ public final class Remo {
         }
     }
 
+    /// Unregister a capability by name.
+    ///
+    /// Returns `true` if the capability existed and was removed.
+    @discardableResult
+    public static func unregister(_ name: String) -> Bool {
+        name.withCString { namePtr in
+            remo_unregister_capability(namePtr)
+        }
+    }
+
     /// List capabilities registered on this device.
     public static func listCapabilities() -> [String] {
         _ = _ensureStarted
@@ -135,6 +145,8 @@ public final class Remo {
     public static func start(port: UInt16 = defaultPort) {}
     public static func stop() {}
     public static func register(_ name: String, handler: @escaping ([String: Any]) -> [String: Any]) {}
+    @discardableResult
+    public static func unregister(_ name: String) -> Bool { false }
     public static func listCapabilities() -> [String] { [] }
 }
 

--- a/swift/RemoSwift/Sources/RemoSwift/include/remo.h
+++ b/swift/RemoSwift/Sources/RemoSwift/include/remo.h
@@ -1,6 +1,7 @@
 #ifndef REMO_H
 #define REMO_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -26,6 +27,10 @@ typedef char* (*remo_capability_callback)(void* context, const char* params_json
 void remo_register_capability(const char* name,
                               void* context,
                               remo_capability_callback callback);
+
+/// Unregister a capability by name.
+/// Returns true if it existed and was removed, false otherwise.
+bool remo_unregister_capability(const char* name);
 
 /// Free a Rust-allocated string.
 void remo_free_string(char* ptr);


### PR DESCRIPTION
## Summary

- Add `Remo.unregister(_:)` / `[RMRemo unregisterCapability:]` API across the full stack (Rust FFI → C header → Swift → ObjC)
- Refactor Example App to demonstrate **page-level dynamic capabilities**: register on `.task`, unregister on `.onDisappear`
- Fix Swift 6 `@MainActor` isolation crash when Remo handlers capture `@Environment` stores

## Capability scoping in Example App

| Scope | Capabilities | Lifecycle |
|-------|-------------|-----------|
| Global | `navigate`, `state.*`, `ui.*` | App launch |
| Home tab | `counter.increment` | Tab visible |
| Items tab | `items.add/remove/clear` | Tab visible |
| Detail page | `detail.getInfo` | Push → Pop |

## Test plan

- [x] `cargo test -p remo-sdk` — 5 tests pass (2 new unregister tests)
- [x] Build Example App with `REMO_LOCAL=1`
- [x] Verify `counter.increment` appears/disappears when switching Home ↔ Items
- [x] Verify `items.*` appears/disappears when switching Items ↔ Home
- [x] Verify `counter.increment` call works without crash (Swift 6 isolation fix)
- [x] Full round-trip: Home → Items → Home → increment → Items → add → Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)