### PR TITLE
docs: add network trace PRD and spec

### DIFF
--- a/prd/README.md
+++ b/prd/README.md
@@ -1,0 +1,47 @@
+# Remo Network Trace PRD
+
+## Summary
+
+Remo Network Trace is an agent-first network inspection product for Remo-enabled iOS apps. The current PRD scope is intentionally limited to SDK-side network capture.
+
+Product docs in `/prd` stay high-level. Technical design details live in `/spec`.
+
+## Current Scope
+
+- Capture most app HTTP/HTTPS traffic that flows through `URLSession`.
+- Work without app-specific knowledge of higher-level wrappers like Alamofire.
+- Produce structured request lifecycle signals for later agent and UI use.
+- Keep capture debug-only and read-only.
+
+## Current Non-Goals
+
+- Device-wide traffic capture
+- MITM proxying
+- Replay, blocking, or throttling requests
+- Daemon trace storage, agent APIs, and UI in this phase
+
+## Functional Breakdown
+
+| Area | Product Goal | PRD | Spec |
+|---|---|---|
+| SDK Network Capture | Observe app network activity inside Remo-enabled apps | [sdk-network-capture/README.md](./sdk-network-capture/README.md) | [../spec/sdk-network-capture/README.md](../spec/sdk-network-capture/README.md) |
+
+## Target Users
+
+- AI agents using Remo to build, test, and debug iOS apps
+- iOS developers debugging Remo-enabled apps
+
+## Product Principles
+
+- Agent-first: capture should be structured so later agent APIs are possible
+- App-aware: capture should fit Remo-enabled apps, not generic proxy workflows
+- Honest coverage: optimize for most app HTTP traffic, not all device traffic
+- Debug-safe: debug-only and low-friction for development
+- Reusable foundation: later daemon and UI work should build on this capture model
+
+## Next Likely Expansion
+
+- Define the normalized network event schema
+- Decide how the daemon should ingest and retain request records
+- Add agent workflows for trace retrieval and comparison
+- Add a thin human inspection UI once the underlying model is stable

--- a/prd/sdk-network-capture/README.md
+++ b/prd/sdk-network-capture/README.md
@@ -1,0 +1,48 @@
+# SDK Network Capture
+
+## Purpose
+
+Capture most app HTTP traffic inside Remo-enabled iOS apps without requiring app-specific knowledge of higher-level networking wrappers.
+
+## Why It Matters
+
+Today Remo can observe UI state, screenshots, and capability calls, but it cannot tell an agent what network activity happened after an action. That makes it hard to distinguish:
+
+- UI rendering bugs
+- backend failures
+- auth issues
+- response contract drift
+- performance bottlenecks
+
+## Product Scope
+
+- Debug-only
+- App-scoped
+- Read-only
+- Optimized for most `URLSession` traffic
+- Not a device-wide proxy
+
+## Requirements
+
+- Intercept most `URLSession` requests made by the app in debug builds.
+- Work regardless of whether the app uses raw `URLSession`, Alamofire, or other wrappers built on top of `URLSession`.
+- Capture enough request, response, and timing data to support debugging.
+- Preserve a stable request identity so later systems can query and correlate network activity.
+- Keep runtime overhead low enough for normal development use.
+
+## Success Criteria
+
+- Most app HTTP traffic appears without app-specific instrumentation.
+- Agents and developers can tell which request failed or became slow after an action.
+- Capture overhead is low enough for routine development use.
+
+## Out Of Scope
+
+- Device-wide traffic capture
+- MITM proxying
+- Replay, blocking, or throttling requests
+- Full daemon/query/UI design
+
+## Related Technical Design
+
+- [SDK Network Capture Spec](../../spec/sdk-network-capture/README.md)

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,16 @@
+# Remo Network Trace Specs
+
+## Summary
+
+Technical design details for Remo Network Trace live in `/spec`. These documents describe implementation shape, capture mechanisms, data boundaries, risks, and engineering constraints.
+
+## Areas
+
+| Area | Purpose | Doc |
+|---|---|---|
+| SDK Network Capture | Technical design for observing app HTTP traffic in debug builds | [sdk-network-capture/README.md](./sdk-network-capture/README.md) |
+
+## Relationship To PRD
+
+- `/prd` explains product intent, scope, and user value.
+- `/spec` explains how the chosen product scope can be implemented.

--- a/spec/sdk-network-capture/README.md
+++ b/spec/sdk-network-capture/README.md
@@ -1,0 +1,70 @@
+# SDK Network Capture Spec
+
+## Goal
+
+Capture most app HTTP traffic inside Remo-enabled iOS apps in debug builds, without needing to know the app's higher-level networking wrapper.
+
+## Recommended Approach
+
+Use a hybrid model:
+
+- `URLProtocol` for broad interception of `URLSession`-based traffic
+- `URLSessionTaskMetrics` for timing fidelity
+
+This is the closest Remo analogue to how Chrome DevTools observes browser traffic from inside the browser stack rather than through an external proxy.
+
+## Capture Model
+
+### Request Observation
+
+- Intercept most `URLSession` requests made by the app in debug builds.
+- Support wrappers built on top of `URLSession`, including common cases like Alamofire.
+- Assign a stable `request_id` for every observed request.
+- Emit lifecycle events for start, redirect, response, finish, and failure.
+
+### Request And Response Data
+
+- Capture method, URL, host, path, query, and headers.
+- Capture request and response body metadata.
+- Capture bounded body previews when content type and size are safe.
+- Capture response status, response headers, MIME type, and content length when available.
+
+### Timing
+
+- Attach timing metrics to the same `request_id`.
+- Support total duration and timing breakdowns when provided by `URLSessionTaskMetrics`.
+- Preserve redirect timing and retry visibility when possible.
+
+### Context
+
+- Attach device ID, app session ID, and trace markers when available.
+- Allow later correlation with Remo capability invocations or action markers.
+
+## Constraints
+
+- Debug builds only
+- Read-only inspection only
+- Best-effort coverage outside `URLSession` is not guaranteed
+- Streaming and very large bodies are not first-class in v1
+
+## Design Risks
+
+- Some third-party SDKs may bypass the interception path.
+- Redirects and retries can be misinterpreted if request identity is not modeled carefully.
+- Body capture can become expensive or unsafe without strict limits.
+
+## Engineering Guardrails
+
+- Keep body capture size-limited.
+- Redact obvious secrets before data leaves the app.
+- Prefer partial but correct records over blocking or breaking app traffic.
+- If capture or metrics fail, app networking should continue normally.
+
+## Deferred Design
+
+The following are intentionally out of scope for this spec:
+
+- daemon-side storage and indexing
+- agent query APIs
+- human inspection UI
+- device-wide capture or MITM proxy behavior


### PR DESCRIPTION
## Summary
- add a root `prd/` index and a focused SDK network capture PRD
- add a root `spec/` index and a matching SDK network capture technical spec
- keep product scope lightweight in `prd/` and move implementation detail into `spec/`

## Test Plan
- `git diff --cached --check` passed before commit
- docs-only change; no code tests run