### PR TITLE
feat: default example sdk to local source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ swift/RemoSDK.xcframework/
 # OS
 .DS_Store
 .superpowers/
+docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ The Rust side owns a global `OnceLock<Mutex<RemoGlobal>>` holding the tokio runt
 
 ### Swift layer
 
-`swift/RemoSwift/` wraps the C FFI in a Swift-friendly API. The `RemoSDK.xcframework` is the binary artifact distributed via the `remo-spm` repo. `REMO_LOCAL=1` env var switches example app to use local monorepo source instead of the published SPM package.
+`swift/RemoSwift/` wraps the C FFI in a Swift-friendly API. The `RemoSDK.xcframework` is the binary artifact distributed via the `remo-spm` repo. The example app defaults to the local monorepo package and uses `REMO_USE_REMOTE=1` only when explicitly validating the published SPM package.
 
 The SDK is `#if DEBUG` only — it does not ship in release builds.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -499,7 +499,7 @@ The release CI pipeline (`release.yml`) builds the XCFramework, zips it, and pus
 
 ### 8.4 Xcode integration
 
-1. Add the `remo-spm` SPM package dependency (or the local `RemoSwift` package for development).
+1. Consumer apps add the `remo-spm` SPM package dependency. Inside this monorepo, the example app defaults to the local `RemoSwift` package and uses `REMO_USE_REMOTE=1` when explicitly validating the published package.
 2. Register custom capabilities via `Remo.register(...)`. The server auto-starts on first API access — no explicit `Remo.start()` needed.
 3. Built-in capabilities (view tree, screenshot, device/app info) are available immediately — no registration needed.
 
@@ -604,7 +604,7 @@ CI also runs `scripts/e2e-test.sh` which builds the SDK, CLI, and example app, l
 | Dependency | Source | Used for |
 |---|---|---|
 | `CRemo` | Binary target in `RemoSDK.xcframework` | Rust FFI binding |
-| `RemoSwift` | Local SPM package (or via `remo-spm` remote) | Swift wrapper API |
+| `RemoSwift` | Local SPM package in this monorepo example, or via `remo-spm` for published distribution | Swift wrapper API |
 
 ### 10.3 Build tools
 

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -10,11 +10,11 @@ The app includes both SwiftUI and UIKit integration examples:
 ## Run
 
 ```bash
-# Option 1: Use published SDK (default)
+# Option 1: Use local monorepo SDK (default)
 open RemoExample.xcworkspace
 
-# Option 2: Use local monorepo source (for SDK development)
-REMO_LOCAL=1 xcodebuild build -workspace RemoExample.xcworkspace -scheme RemoExample \
+# Option 2: Opt into the published SDK
+REMO_USE_REMOTE=1 xcodebuild build -workspace RemoExample.xcworkspace -scheme RemoExample \
   -destination 'platform=iOS Simulator,name=iPhone 17'
 ```
 

--- a/examples/ios/RemoExamplePackage/Package.swift
+++ b/examples/ios/RemoExamplePackage/Package.swift
@@ -3,17 +3,17 @@
 import PackageDescription
 import Foundation
 
-// Set REMO_LOCAL=1 to use the monorepo source (for development).
-// Default: use the published remo-spm binary package.
-let useLocal = ProcessInfo.processInfo.environment["REMO_LOCAL"] != nil
+// Default: use the monorepo source package.
+// Set REMO_USE_REMOTE=1 to opt into the published remo-spm package.
+let useRemote = ProcessInfo.processInfo.environment["REMO_USE_REMOTE"] != nil
 
-let remoDependency: Package.Dependency = useLocal
-    ? .package(path: "../../../swift/RemoSwift")
-    : .package(url: "https://github.com/yjmeqt/remo-spm.git", from: "0.4.0")
+let remoDependency: Package.Dependency = useRemote
+    ? .package(url: "https://github.com/yjmeqt/remo-spm.git", from: "0.4.0")
+    : .package(path: "../../../swift/RemoSwift")
 
 let remoProduct: Target.Dependency = .product(
     name: "RemoSwift",
-    package: useLocal ? "RemoSwift" : "remo-spm"
+    package: useRemote ? "remo-spm" : "RemoSwift"
 )
 
 let package = Package(

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 #   ARTIFACTS_DIR  — where to save screenshots/recordings (default: /tmp/remo-e2e)
 #   DERIVED_DATA_PATH — explicit Xcode DerivedData path for RemoExample builds
 #   REMO_BIN       — path to remo binary (default: built from source)
+#   REMO_USE_REMOTE — set to 1 to build the example app against published remo-spm
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -173,7 +174,7 @@ build_example_app() {
         xcodebuild_args+=(-derivedDataPath "$DERIVED_DATA_PATH")
     fi
 
-    REMO_LOCAL=1 xcodebuild "${xcodebuild_args[@]}" 2>&1 | tail -5
+    xcodebuild "${xcodebuild_args[@]}" 2>&1 | tail -5
 }
 
 find_app_path() {
@@ -220,7 +221,6 @@ else
 
     log "Building example app..."
     resolve_device_uuid
-
     build_example_app
 
     # Find the built app bundle

--- a/tests/example_sdk_default.sh
+++ b/tests/example_sdk_default.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PKG="$ROOT/examples/ios/RemoExamplePackage"
+
+default_dump="$(swift package dump-package --package-path "$PKG")"
+echo "$default_dump" | jq -e '.dependencies[] | .fileSystem[]? | select(.path | endswith("/swift/RemoSwift"))' >/dev/null
+echo "$default_dump" | jq -e '.targets[] | select(.name == "RemoExampleFeature") | .dependencies[] | select(.product[0] == "RemoSwift" and .product[1] == "RemoSwift")' >/dev/null
+
+remote_dump="$(env REMO_USE_REMOTE=1 swift package dump-package --package-path "$PKG")"
+echo "$remote_dump" | jq -e '.dependencies[] | .sourceControl[]? | select(.location.remote[0].urlString == "https://github.com/yjmeqt/remo-spm.git")' >/dev/null
+echo "$remote_dump" | jq -e '.targets[] | select(.name == "RemoExampleFeature") | .dependencies[] | select(.product[0] == "RemoSwift" and .product[1] == "remo-spm")' >/dev/null
+
+! rg -n "REMO_LOCAL" \
+  "$ROOT/examples/ios/RemoExamplePackage/Package.swift" \
+  "$ROOT/scripts/e2e-test.sh" \
+  "$ROOT/examples/ios/README.md" \
+  "$ROOT/AGENTS.md" \
+  "$ROOT/SPEC.md"


### PR DESCRIPTION
## Summary
- default the example package to the local monorepo `RemoSwift` source and use `REMO_USE_REMOTE=1` for the published SDK path
- update the example-facing docs, spec guidance, and e2e script to match the new local-first behavior
- ignore `docs/superpowers/` and add a regression script covering both manifest selection modes and stale env-var references

## Test Plan
- [x] `bash tests/example_sdk_default.sh`
- [x] `cargo fmt --check` (pre-commit hook)
- [x] `cargo clippy` (pre-commit hook)
