### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-04-19
+
+### Added
+
+- **Tart-first contributor workflow**: Reproducible Tart VM setup for contributors
+
+### Changed
+
+- **Example app**: Default to local SDK source for easier in-tree development
+- **Docs**: Repositioned Remo around capabilities
+
 ## [0.4.3] - 2026-03-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,7 +1404,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remo-bonjour"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "thiserror",
  "tokio",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "remo-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -1433,7 +1433,7 @@ dependencies = [
 
 [[package]]
 name = "remo-daemon"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "axum",
  "chrono",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "remo-desktop"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "axum",
  "dashmap",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "remo-objc"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "objc2",
  "objc2-foundation",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "remo-protocol"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "serde",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "remo-sdk"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "dashmap",
  "futures",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "remo-transport"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "futures",
  "remo-protocol",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "remo-usbmuxd"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "bytes",
  "plist",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "remo-workspace"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "axum",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ unsafe_code = "warn"
 unused_qualifications = "warn"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT"

--- a/swift/Remo.podspec
+++ b/swift/Remo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Remo'
-  s.version      = '0.4.3'
+  s.version      = '0.4.4'
   s.summary      = 'Remote control bridge for iOS apps — infrastructure for agentic iOS development.'
   s.description  = <<-DESC
     Remo gives AI agents eyes and hands on iOS. Register capabilities in your app,


### PR DESCRIPTION
## Summary
- Bump workspace to 0.4.4 (Cargo.toml + Cargo.lock across all crates)
- Bump `Remo.podspec` to 0.4.4
- CHANGELOG entry covering Tart contributor workflow, local-source example default, and docs repositioning

## Release plan
After merge, tag `v0.4.4` on main to trigger `.github/workflows/release.yml`, which:
- Builds `RemoSDK.xcframework.zip` and CLI tarballs (arm64 + x86_64)
- Creates the GitHub Release
- Auto-updates `yjmeqt/remo-spm` (binaryTarget URL + checksum) and tags it
- Auto-updates `yjmeqt/homebrew-tap` Formula

## Test plan
- [ ] CI green on this PR (fmt, clippy, tests, e2e)
- [ ] After tag push, verify release workflow succeeds on macos-26
- [ ] Verify `remo-spm` tag `0.4.4` created with correct checksum
- [ ] Verify `homebrew-tap` Formula updated to 0.4.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)