### PR TITLE
fix(tart): avoid double-stop in create-dev-vm when mounts change

### DIFF
--- a/scripts/tart/create-dev-vm.sh
+++ b/scripts/tart/create-dev-vm.sh
@@ -259,7 +259,9 @@ fi
 
 if remo_tart_vm_is_running "${VM_NAME}" && [[ "${MOUNTS_CHANGED}" -eq 1 ]]; then
     remo_tart_launchd_remove "${VM_NAME}"
-    tart stop "${VM_NAME}"
+    if remo_tart_vm_is_running "${VM_NAME}"; then
+        tart stop "${VM_NAME}"
+    fi
 fi
 
 if ! remo_tart_vm_is_running "${VM_NAME}"; then


### PR DESCRIPTION
## Summary

- `create-dev-vm.sh` unconditionally ran `tart stop` after `remo_tart_launchd_remove` in the mounts-changed branch. Removing the launchd job can already transition the VM to stopped, so the follow-up `tart stop` errored with exit 2 (`VM "<name>" is not running`), killing the attach flow any time a new worktree mount triggered a restart.
- Guard the `tart stop` with a fresh `remo_tart_vm_is_running` check, matching the pattern the `--recreate` branch (lines 244–250 of the same file) already uses.

## Repro (before this PR)

1. With a running `remo-dev` VM, check out a new worktree.
2. Run `scripts/tart/use-worktree-dev-vm.sh --no-verify`.
3. Script exits 2 with `VM "remo-dev" is not running`; VM ends up stopped; re-running the same command works because the first branch is then skipped.

## Test plan

- [x] Syntax check: `bash -n scripts/tart/create-dev-vm.sh`
- [x] `cargo fmt --check` and `cargo clippy` (pre-commit hooks)
- [ ] Manual: trigger a mount change on a running VM and confirm `use-worktree-dev-vm.sh --no-verify` completes end-to-end without the double-stop error

🤖 Generated with [Claude Code](https://claude.com/claude-code)