### PR TITLE
docs(website): update capability snippet to typed macro API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ swift/RemoSDK.xcframework/
 .DS_Store
 .superpowers/
 docs/superpowers/
+
+#pnpm
+.pnpm-store/

--- a/website/src/components/DemoHero/timeline.ts
+++ b/website/src/components/DemoHero/timeline.ts
@@ -65,14 +65,14 @@ export const DEMO_STEPS: DemoStep[] = [
     time: 5,
     terminal: {
       type: "claude",
-      text: "I see UI effects and a Grid tab with feed and items. I'll register capabilities for each one.",
+      text: "I see UI effects and a Grid tab with feed and items. I'll declare typed capabilities for each one.",
     },
   },
   {
     time: 6.5,
     terminal: {
       type: "command",
-      text: '❯ Edit UIKitDemoViewController.swift — added Remo.register("grid.*", ...)',
+      text: "❯ Edit UIKitDemoViewController.swift — added #Remo { #remoScope { #remoCap(Grid*.self) { … } } }",
     },
   },
   {

--- a/website/src/components/FeatureShowcase/CapabilitySection.tsx
+++ b/website/src/components/FeatureShowcase/CapabilitySection.tsx
@@ -69,32 +69,84 @@ function RegisterCode() {
   return (
     <div style={{ fontFamily: "'SF Mono','Fira Code',monospace" }}>
       <div className={comment}>
-        {"// Your iOS app — one line to expose a capability"}
+        {"// Typed capability + Swift macros — debug-only, auto-unregister"}
       </div>
       <div>
-        <span className={kw}>Remo</span>
-        {"."}<span className={fn}>register</span>
-        {"("}<span className={str}>"counter.increment"</span>
-        {") { params "}
+        <span className={kw}>enum</span>{" "}
+        <span className={fn}>Increment</span>
+        {": "}
+        <span className={kw}>RemoCapability</span>
+        {" {"}
+      </div>
+      <div className="pl-4">
+        <span className={kw}>static let</span>{" "}
+        <span className={plain}>name</span>
+        {" = "}
+        <span className={str}>"counter.increment"</span>
+      </div>
+      <div className="pl-4">
+        <span className={kw}>struct</span>{" "}
+        <span className={fn}>Request</span>
+        {": "}
+        <span className={kw}>Decodable</span>
+        {" { "}
+        <span className={kw}>let</span>{" "}
+        <span className={plain}>amount</span>
+        {": "}
+        <span className={kw}>Int</span>
+        {"? }"}
+      </div>
+      <div className="pl-4">
+        <span className={kw}>struct</span>{" "}
+        <span className={fn}>Response</span>
+        {": "}
+        <span className={kw}>Encodable</span>
+        {" { "}
+        <span className={kw}>let</span>{" "}
+        <span className={plain}>count</span>
+        {": "}
+        <span className={kw}>Int</span>
+        {" }"}
+      </div>
+      <div>{"}"}</div>
+      <div>&nbsp;</div>
+      <div>
+        <span className={kw}>await</span>{" "}
+        <span className={fn}>#Remo</span>
+        {" {"}
+      </div>
+      <div className="pl-4">
+        <span className={kw}>await</span>{" "}
+        <span className={fn}>#remoScope</span>
+        {" {"}
+      </div>
+      <div className="pl-8">
+        <span className={fn}>#remoCap</span>
+        {"("}
+        <span className={plain}>Increment</span>
+        {".self) { "}
+        <span className={plain}>req</span>{" "}
         <span className={kw}>in</span>
       </div>
-      <div className="pl-4">
+      <div className="pl-12">
         <span className={plain}>counter</span>
-        {" += params["}
-        <span className={str}>"amount"</span>
-        {"] "}
-        <span className={kw}>as?</span>
-        {" "}<span className={plain}>Int</span>
-        {" ?? "}<span className={plain}>1</span>
+        {" += "}
+        <span className={plain}>req</span>
+        {".amount ?? "}
+        <span className={plain}>1</span>
       </div>
-      <div className="pl-4">
+      <div className="pl-12">
         <span className={kw}>return</span>
-        {" ["}
-        <span className={str}>"count"</span>
+        {" ."}
+        <span className={fn}>init</span>
+        {"("}
+        <span className={plain}>count</span>
         {": "}
         <span className={plain}>counter</span>
-        {"]"}
+        {")"}
       </div>
+      <div className="pl-8">{"}"}</div>
+      <div className="pl-4">{"}"}</div>
       <div>{"}"}</div>
     </div>
   );
@@ -152,8 +204,8 @@ export function CapabilitySection() {
       <SectionHeader
         label="Capability Invocation"
         labelColor="#34d399"
-        title="Register in Swift. Call from anywhere."
-        subtitle="Define named handlers in your app. Agents discover and invoke them at runtime — structured input, structured output."
+        title="Declare in Swift. Call from anywhere."
+        subtitle="Swift macros expose typed capabilities from your app. Agents discover and invoke them at runtime — structured input, structured output."
       />
 
       {/* Pipeline */}


### PR DESCRIPTION
## Summary
- Update the website's Capability Invocation showcase to use the new `#Remo` / `#remoScope` / `#remoCap` Swift macros with typed `Request`/`Response` types.
- Refresh the demo hero timeline narration and terminal line to match the new macro-based API.
- Ignore `.pnpm-store/` in the repo root.

## Test plan
- [ ] `pnpm --filter website dev` and visually confirm the Capability Invocation section renders the updated snippet.
- [ ] Verify the DemoHero timeline step 5/6.5 text matches the new wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)