### PR TITLE
feat(remo-tart): port Tart lifecycle logic to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .worktrees/
 .tart/*
 !.tart/project.sh
+!.tart/project.toml
+!.tart/provision.sh
+!.tart/verify-worktree.sh
 !.tart/packs/
 !.tart/packs/*.sh
 

--- a/.tart/project.toml
+++ b/.tart/project.toml
@@ -1,0 +1,16 @@
+[project]
+slug = "remo"
+
+[vm]
+name = "remo-dev"
+base_image = "ghcr.io/cirruslabs/macos-tahoe-xcode:26"
+cpu = 6
+memory_gb = 12
+network = "bridged:en0"
+
+[packs]
+enabled = ["shell", "ios", "rust", "node", "agents"]
+
+[scripts]
+provision = ".tart/provision.sh"
+verify_worktree = ".tart/verify-worktree.sh"

--- a/.tart/provision.sh
+++ b/.tart/provision.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+make setup

--- a/.tart/verify-worktree.sh
+++ b/.tart/verify-worktree.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cargo check --workspace
+./build-ios.sh sim

--- a/tools/remo-tart/src/remo_tart/cli.py
+++ b/tools/remo-tart/src/remo_tart/cli.py
@@ -63,22 +63,30 @@ def _resolve_primary_mount(
 
     This is a CLI-specific helper — not exported from mount.py.
     """
-    resolved_cwd = cwd.resolve()
+    if not entries:
+        raise RemoTartError(
+            "no mounts attached to this VM",
+            hint="run `remo-tart use` from this worktree to attach it",
+        )
+    cwd_resolved = cwd.resolve()
     for entry in entries:
         try:
-            if entry.host_path.resolve() == resolved_cwd:
+            if entry.host_path.resolve() == cwd_resolved:
                 return entry
         except OSError:
-            pass
-    # Fallback: return the first non-git-root entry, or just the first
-    for entry in entries:
-        if not entry.name.endswith("-git-root"):
-            return entry
-    if entries:
-        return entries[0]
-    from remo_tart.mount import MountEntry
-
-    return MountEntry(name="unknown", host_path=cwd)
+            continue
+    # No exact match — fall back to first non-git-root entry, but warn
+    non_bridge = [e for e in entries if not e.name.endswith("-git-root")]
+    if non_bridge:
+        get_console().print(
+            f"[yellow]warning:[/yellow] cwd {cwd} does not match any mount; "
+            f"using mount '{non_bridge[0].name}'"
+        )
+        return non_bridge[0]
+    raise RemoTartError(
+        f"cwd {cwd} is not a recorded mount and no non-bridge mount exists",
+        hint="run `remo-tart use` from this worktree to attach it",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -225,7 +233,8 @@ def ssh(ctx: click.Context, ssh_args: tuple[str, ...]) -> None:
             f"vm is not running: {name}",
             hint="run `remo-tart up` to start and connect, or `remo-tart start` to only start",
         )
-    code = vm.exec_interactive(name, list(ssh_args))
+    argv = list(ssh_args) if ssh_args else ["/bin/zsh", "-l"]
+    code = vm.exec_interactive(name, argv)
     ctx.exit(code)
 
 
@@ -243,7 +252,6 @@ def destroy(ctx: click.Context, force: bool) -> None:
         confirmed = click.confirm(f"Destroy VM '{name}'? This cannot be undone.", default=False)
         if not confirmed:
             ctx.exit(1)
-            return
     label = launchd.label(name)
     launchd.remove(label)
     if vm.exists(name):

--- a/tools/remo-tart/src/remo_tart/cli.py
+++ b/tools/remo-tart/src/remo_tart/cli.py
@@ -1,19 +1,89 @@
 """remo-tart command-line entry point.
 
-PR 1: every subcommand dispatches to scripts/tart/*.sh. The real logic
-moves to Python in PR 2.
+PR 2: every subcommand calls into native Python modules.  The bash shim
+(dispatch.py / scripts/tart/*.sh) is no longer invoked from here.
 """
 
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import click
 
-from remo_tart import __version__
+from remo_tart import __version__, launchd, mount, vm, worktree
+from remo_tart import connect as _connect
+from remo_tart import doctor as _doctor
+from remo_tart import ssh as _ssh
+from remo_tart import status as _status
 from remo_tart.console import get_console, render_error
-from remo_tart.dispatch import bash_dispatch
 from remo_tart.errors import RemoTartError
+from remo_tart.mount import manifest_read, mount_name_for_path
+from remo_tart.paths import (
+    mount_manifest_path,
+    ssh_include_path,
+    ssh_key_path,
+    user_ssh_config_path,
+    vm_log_path,
+)
+
+# TODO(pr3): move to config
+_GUEST_USER = "admin"
+
+
+# ---------------------------------------------------------------------------
+# _load_cfg helper
+# ---------------------------------------------------------------------------
+
+
+def _load_cfg(ctx: click.Context):  # type: ignore[return]
+    """Resolve the repo root and load .tart/project.toml. Used by every subcommand."""
+    from remo_tart import config, dispatch
+
+    try:
+        repo = dispatch.find_repo_root()
+    except RemoTartError:
+        raise
+    project = config.load(repo)
+    ctx.obj["repo_root"] = repo
+    ctx.obj["project"] = project
+    return repo, project
+
+
+# ---------------------------------------------------------------------------
+# CLI-internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_primary_mount(
+    entries: list,  # type: ignore[type-arg]
+    cwd: Path,
+) -> object:
+    """Return the mount entry whose host_path matches cwd, or the first non-bridge entry.
+
+    This is a CLI-specific helper — not exported from mount.py.
+    """
+    resolved_cwd = cwd.resolve()
+    for entry in entries:
+        try:
+            if entry.host_path.resolve() == resolved_cwd:
+                return entry
+        except OSError:
+            pass
+    # Fallback: return the first non-git-root entry, or just the first
+    for entry in entries:
+        if not entry.name.endswith("-git-root"):
+            return entry
+    if entries:
+        return entries[0]
+    from remo_tart.mount import MountEntry
+
+    return MountEntry(name="unknown", host_path=cwd)
+
+
+# ---------------------------------------------------------------------------
+# CLI group
+# ---------------------------------------------------------------------------
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -33,41 +103,58 @@ def main(ctx: click.Context, verbose: int) -> None:
 @click.argument("mode", type=click.Choice(["cli", "vscode", "cursor"]), default="cli")
 @click.pass_context
 def up(ctx: click.Context, mode: str) -> None:
-    """Attach the current worktree, ensure the VM is running, and connect.
-
-    In PR 1 this is approximated as ``use`` + ``connect``. A true idempotent
-    state machine lands in PR 2.
-    """
-    use_result = bash_dispatch("use-worktree-dev-vm.sh", [])
-    if use_result.returncode != 0:
-        ctx.exit(use_result.returncode)
-    connect_result = bash_dispatch("connect-dev-vm.sh", [mode])
-    ctx.exit(connect_result.returncode)
+    """Attach the current worktree, ensure the VM is running, and connect."""
+    repo, project = _load_cfg(ctx)
+    cwd = Path.cwd()
+    outcome = worktree.ensure_attached(repo, project, cwd)
+    name = project.vm.name
+    if mode == "cli":
+        code = _connect.connect_cli(name, _GUEST_USER)
+    elif mode == "vscode":
+        code = _connect.connect_vscode(name, _GUEST_USER, outcome.primary)
+    else:  # cursor
+        code = _connect.connect_cursor(name, _GUEST_USER, outcome.primary)
+    ctx.exit(code)
 
 
 # ---- explicit lifecycle ---------------------------------------------------
 
 
 @main.command()
-@click.argument("worktree", required=False)
+@click.argument("worktree_path", required=False, metavar="PATH")
 @click.pass_context
-def use(ctx: click.Context, worktree: str | None) -> None:
+def use(ctx: click.Context, worktree_path: str | None) -> None:
     """Attach a worktree to the VM (mount + restart if needed)."""
-    args = [worktree] if worktree else []
-    result = bash_dispatch("use-worktree-dev-vm.sh", args)
-    ctx.exit(result.returncode)
+    repo, project = _load_cfg(ctx)
+    path = Path(worktree_path).resolve() if worktree_path else Path.cwd()
+    outcome = worktree.ensure_attached(repo, project, path)
+    get_console().print(
+        f"[green]Attached[/green] {outcome.primary.name} "
+        f"(actions: {', '.join(a.name for a in outcome.actions)})"
+    )
 
 
 @main.command()
 @click.pass_context
 def start(ctx: click.Context) -> None:
-    """Start the VM without changing mounts or connecting.
-
-    PR 1 approximates this by running use-worktree with --no-verify; a real
-    start-only command lands in PR 2.
-    """
-    result = bash_dispatch("use-worktree-dev-vm.sh", ["--no-verify"])
-    ctx.exit(result.returncode)
+    """Start the VM without changing mounts or connecting."""
+    _repo, project = _load_cfg(ctx)
+    name = project.vm.name
+    if not vm.exists(name):
+        raise RemoTartError(
+            "vm does not exist",
+            hint="run remo-tart up to create it",
+        )
+    label = launchd.label(name)
+    log_path = vm_log_path(name)
+    manifest_path = mount_manifest_path(name)
+    mounts = manifest_read(manifest_path)
+    launchd.remove(label)
+    # Truncate log to avoid confusion with stale output
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("")
+    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    launchd.submit(label, tart_args, log_path)
 
 
 @main.command()
@@ -75,8 +162,24 @@ def start(ctx: click.Context) -> None:
 @click.pass_context
 def connect(ctx: click.Context, mode: str) -> None:
     """Connect to the running VM (cli / vscode / cursor)."""
-    result = bash_dispatch("connect-dev-vm.sh", [mode])
-    ctx.exit(result.returncode)
+    _repo, project = _load_cfg(ctx)
+    name = project.vm.name
+    if not vm.is_running(name):
+        raise RemoTartError(
+            f"vm is not running: {name}",
+            hint="run `remo-tart up` to start and connect, or `remo-tart start` to only start",
+        )
+    # Find the primary mount: the one whose host_path matches cwd or first entry
+    manifest_path = mount_manifest_path(name)
+    entries = mount.manifest_read(manifest_path)
+    primary = _resolve_primary_mount(entries, Path.cwd())
+    if mode == "cli":
+        code = _connect.connect_cli(name, _GUEST_USER)
+    elif mode == "vscode":
+        code = _connect.connect_vscode(name, _GUEST_USER, primary)
+    else:  # cursor
+        code = _connect.connect_cursor(name, _GUEST_USER, primary)
+    ctx.exit(code)
 
 
 # ---- observability --------------------------------------------------------
@@ -87,17 +190,27 @@ def connect(ctx: click.Context, mode: str) -> None:
 @click.pass_context
 def status(ctx: click.Context, as_json: bool) -> None:
     """Show VM status."""
-    args = ["--json"] if as_json else []
-    result = bash_dispatch("status-dev-vm.sh", args)
-    ctx.exit(result.returncode)
+    repo, project = _load_cfg(ctx)
+    name = project.vm.name
+    data = _status.collect(name, repo, Path.cwd())
+    output = _status.render_json(data) if as_json else _status.render_human(data)
+    get_console().print(output)
 
 
 @main.command()
 @click.pass_context
 def doctor(ctx: click.Context) -> None:
     """Run host/VM health checks."""
-    result = bash_dispatch("doctor-dev-vm.sh", [])
-    ctx.exit(result.returncode)
+    try:
+        repo, project = _load_cfg(ctx)
+        name = project.vm.name
+    except RemoTartError:
+        # doctor.run_all handles config failure gracefully
+        repo = Path.cwd()
+        name = "unknown"
+    findings = _doctor.run_all(name, repo)
+    print(_doctor.render(findings))
+    ctx.exit(_doctor.exit_code(findings))
 
 
 @main.command(context_settings={"ignore_unknown_options": True})
@@ -105,8 +218,15 @@ def doctor(ctx: click.Context) -> None:
 @click.pass_context
 def ssh(ctx: click.Context, ssh_args: tuple[str, ...]) -> None:
     """Open an SSH session or run a command inside the VM."""
-    result = bash_dispatch("ssh-dev-vm.sh", list(ssh_args))
-    ctx.exit(result.returncode)
+    _repo, project = _load_cfg(ctx)
+    name = project.vm.name
+    if not vm.is_running(name):
+        raise RemoTartError(
+            f"vm is not running: {name}",
+            hint="run `remo-tart up` to start and connect, or `remo-tart start` to only start",
+        )
+    code = vm.exec_interactive(name, list(ssh_args))
+    ctx.exit(code)
 
 
 # ---- destructive ----------------------------------------------------------
@@ -117,9 +237,26 @@ def ssh(ctx: click.Context, ssh_args: tuple[str, ...]) -> None:
 @click.pass_context
 def destroy(ctx: click.Context, force: bool) -> None:
     """Destroy the VM."""
-    args = ["--force"] if force else []
-    result = bash_dispatch("destroy-dev-vm.sh", args)
-    ctx.exit(result.returncode)
+    _repo, project = _load_cfg(ctx)
+    name = project.vm.name
+    if not force:
+        confirmed = click.confirm(f"Destroy VM '{name}'? This cannot be undone.", default=False)
+        if not confirmed:
+            ctx.exit(1)
+            return
+    label = launchd.label(name)
+    launchd.remove(label)
+    if vm.exists(name):
+        vm.delete(name)
+    _ssh.remove_managed_block(ssh_include_path(), name)
+    _ssh.remove_include_from_user_config(user_ssh_config_path(), ssh_include_path())
+    # Optionally remove the SSH key file
+    key = ssh_key_path(name)
+    if key.exists():
+        key.unlink(missing_ok=True)
+    pub = key.with_suffix(".pub")
+    if pub.exists():
+        pub.unlink(missing_ok=True)
 
 
 @main.command(name="clean-worktree")
@@ -127,17 +264,30 @@ def destroy(ctx: click.Context, force: bool) -> None:
 @click.pass_context
 def clean_worktree(ctx: click.Context, path: str | None) -> None:
     """Remove a worktree from the mount manifest."""
-    args = [path] if path else []
-    result = bash_dispatch("clean-worktree-dev-vm.sh", args)
-    ctx.exit(result.returncode)
+    _repo, project = _load_cfg(ctx)
+    resolved = Path(path).resolve() if path else Path.cwd()
+    manifest_path = mount_manifest_path(project.vm.name)
+    mount_name = mount_name_for_path(project.slug, resolved)
+    mount.manifest_remove(manifest_path, mount_name)
+    get_console().print(f"[green]Removed[/green] mount entry '{mount_name}' from manifest.")
 
 
 @main.command()
 @click.pass_context
 def bootstrap(ctx: click.Context) -> None:
     """First-time VM setup (create + provision)."""
-    result = bash_dispatch("bootstrap-dev-vm.sh", [])
-    ctx.exit(result.returncode)
+    get_console().print("[bold]First-time setup[/bold] — creating and provisioning VM…")
+    repo, project = _load_cfg(ctx)
+    cwd = Path.cwd()
+    worktree.ensure_attached(repo, project, cwd)
+    name = project.vm.name
+    code = _connect.connect_cli(name, _GUEST_USER)
+    ctx.exit(code)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 
 def _run() -> int:

--- a/tools/remo-tart/src/remo_tart/config.py
+++ b/tools/remo-tart/src/remo_tart/config.py
@@ -1,0 +1,86 @@
+"""Load and validate .tart/project.toml."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+
+from remo_tart.errors import RemoTartError
+
+
+class VmConfig(BaseModel):
+    name: str
+    base_image: str
+    cpu: int = Field(ge=1)
+    memory_gb: int = Field(ge=1)
+    network: str
+
+
+class ScriptsConfig(BaseModel):
+    provision: str
+    verify_worktree: str
+
+
+class ProjectConfig(BaseModel):
+    slug: str
+    vm: VmConfig
+    packs: list[str]
+    scripts: ScriptsConfig
+
+
+def _toml_path(repo_root: Path) -> Path:
+    return repo_root / ".tart" / "project.toml"
+
+
+def _legacy_sh_path(repo_root: Path) -> Path:
+    return repo_root / ".tart" / "project.sh"
+
+
+def legacy_project_sh_present(repo_root: Path) -> bool:
+    return _legacy_sh_path(repo_root).is_file()
+
+
+def _parse(raw: bytes, repo_root: Path) -> ProjectConfig:
+    try:
+        data: dict[str, Any] = tomllib.loads(raw.decode("utf-8"))
+    except tomllib.TOMLDecodeError as err:
+        raise RemoTartError(
+            f"invalid TOML in {_toml_path(repo_root)}: {err}",
+            hint="fix the syntax error; see docs/tart-dev-vm.md for the expected schema",
+        ) from err
+    # pydantic expects structure: {slug, vm, packs, scripts}
+    project = data.get("project", {}) or {}
+    payload = {
+        "slug": project.get("slug"),
+        "vm": data.get("vm"),
+        "packs": (data.get("packs") or {}).get("enabled", []),
+        "scripts": data.get("scripts"),
+    }
+    try:
+        return ProjectConfig.model_validate(payload)
+    except ValidationError as err:
+        raise RemoTartError(
+            f"invalid config in {_toml_path(repo_root)}: {err}",
+            hint="see docs/tart-dev-vm.md for the expected schema",
+        ) from err
+
+
+def load(repo_root: Path) -> ProjectConfig:
+    toml = _toml_path(repo_root)
+    if not toml.is_file():
+        if legacy_project_sh_present(repo_root):
+            raise RemoTartError(
+                f"missing {toml} (found legacy .tart/project.sh)",
+                hint=(
+                    "create .tart/project.toml from your project.sh values; see "
+                    "docs/tart-dev-vm.md for the schema and a migration example"
+                ),
+            )
+        raise RemoTartError(
+            f"missing {toml}",
+            hint="create .tart/project.toml; see docs/tart-dev-vm.md for the schema",
+        )
+    return _parse(toml.read_bytes(), repo_root)

--- a/tools/remo-tart/src/remo_tart/connect.py
+++ b/tools/remo-tart/src/remo_tart/connect.py
@@ -1,0 +1,68 @@
+"""Connect dispatchers — CLI (ssh), VS Code, and Cursor."""
+
+from __future__ import annotations
+
+import subprocess
+
+from remo_tart.mount import MountEntry
+from remo_tart.ssh import ssh_alias
+
+# Guest-side shared folder root (tart virtiofs / directory-share mount point).
+_GUEST_SHARED_ROOT = "/Volumes/My Shared Files"
+
+
+def connect_cli(vm_name: str, guest_user: str) -> int:
+    """Drop into an interactive SSH shell on *vm_name*.
+
+    Uses the SSH alias ``tart-<vm-name>`` (baked into the SSH config by
+    :func:`remo_tart.ssh.upsert_managed_block`).  *guest_user* is kept for
+    future use when we may bypass the alias and connect directly.
+
+    Returns the ssh process exit code.
+    """
+    alias = ssh_alias(vm_name)
+    return subprocess.run(["ssh", alias], check=False).returncode
+
+
+def connect_vscode(
+    vm_name: str,
+    guest_user: str,
+    mount: MountEntry,
+    *,
+    new_window: bool = False,
+) -> int:
+    """Open *mount* in VS Code via the SSH remote extension.
+
+    Builds a ``vscode-remote://ssh-remote+<alias>/<guest-path>`` URI and
+    passes it to the ``code`` CLI.  *guest_user* is kept for future use.
+
+    Returns the ``code`` process exit code.
+    """
+    alias = ssh_alias(vm_name)
+    guest_path = f"{_GUEST_SHARED_ROOT}/{mount.name}"
+    uri = f"vscode-remote://ssh-remote+{alias}{guest_path}"
+    window_flag = "--new-window" if new_window else "--reuse-window"
+    argv = ["code", window_flag, "--folder-uri", uri]
+    return subprocess.run(argv, check=False).returncode
+
+
+def connect_cursor(
+    vm_name: str,
+    guest_user: str,
+    mount: MountEntry,
+    *,
+    new_window: bool = False,
+) -> int:
+    """Open *mount* in Cursor via the SSH remote extension.
+
+    Identical to :func:`connect_vscode` but invokes ``cursor`` instead of
+    ``code``.  Cursor accepts the same ``vscode-remote://`` URI scheme.
+
+    Returns the ``cursor`` process exit code.
+    """
+    alias = ssh_alias(vm_name)
+    guest_path = f"{_GUEST_SHARED_ROOT}/{mount.name}"
+    uri = f"vscode-remote://ssh-remote+{alias}{guest_path}"
+    window_flag = "--new-window" if new_window else "--reuse-window"
+    argv = ["cursor", window_flag, "--folder-uri", uri]
+    return subprocess.run(argv, check=False).returncode

--- a/tools/remo-tart/src/remo_tart/doctor.py
+++ b/tools/remo-tart/src/remo_tart/doctor.py
@@ -1,0 +1,263 @@
+"""VM health checks. Each check returns a list of Finding instances.
+
+Port of scripts/tart/doctor-dev-vm.sh.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from remo_tart import config, launchd, mount, paths, vm
+from remo_tart.errors import RemoTartError
+
+
+@dataclass(frozen=True)
+class Finding:
+    level: str  # "ok" | "warning" | "issue"
+    message: str
+    hint: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def _check_config(repo_root: Path) -> tuple[list[Finding], object | None]:
+    """Check 1: .tart/project.toml is loadable.
+
+    Returns (findings, project) where project is None on failure.
+    """
+    try:
+        project = config.load(repo_root)
+        toml_path = repo_root / ".tart" / "project.toml"
+        return [Finding("ok", f"project.toml loaded: {toml_path}")], project
+    except RemoTartError as err:
+        return [Finding("issue", str(err), hint=err.hint)], None
+    except Exception as err:
+        return [Finding("issue", f"config load failed: {err}")], None
+
+
+def _check_vm_exists(vm_name: str) -> tuple[list[Finding], bool]:
+    """Check 2: VM exists in the local tart list."""
+    try:
+        if vm.exists(vm_name):
+            return [Finding("ok", f"vm exists: {vm_name}")], True
+        return [Finding("issue", f"vm does not exist: {vm_name}")], False
+    except Exception as err:
+        return [Finding("issue", f"vm.exists check failed: {err}")], False
+
+
+def _check_vm_running(vm_name: str) -> tuple[list[Finding], bool]:
+    """Check 3: VM is running (warning if not — stopped is valid for some workflows)."""
+    try:
+        if vm.is_running(vm_name):
+            return [Finding("ok", f"vm is running: {vm_name}")], True
+        return [Finding("warning", f"vm is not running: {vm_name}")], False
+    except Exception as err:
+        return [Finding("warning", f"vm.is_running check failed: {err}")], False
+
+
+def _check_launchd(vm_name: str, vm_running: bool, vm_exists: bool) -> list[Finding]:
+    """Check 4: Launchd job present; cross-check with running state."""
+    findings: list[Finding] = []
+    label_str = launchd.label(vm_name)
+    try:
+        job_present = launchd.job_present(label_str)
+    except Exception as err:
+        findings.append(Finding("warning", f"launchd check failed: {err}"))
+        return findings
+
+    if job_present:
+        findings.append(Finding("ok", f"launchd job is loaded: {label_str}"))
+    else:
+        findings.append(Finding("warning", f"launchd job is not loaded: {label_str}"))
+
+    # Cross-checks
+    if not vm_exists and job_present:
+        findings.append(Finding("warning", f"stale launchd job for missing vm: {label_str}"))
+    if vm_running and not job_present:
+        findings.append(Finding("warning", f"vm is running outside launchd management: {vm_name}"))
+
+    return findings
+
+
+def _check_manifest(vm_name: str) -> tuple[list[Finding], list]:
+    """Checks 5 & 6: Manifest exists/non-empty; each host path is a real directory."""
+    findings: list[Finding] = []
+    manifest_path = paths.mount_manifest_path(vm_name)
+
+    try:
+        entries = mount.manifest_read(manifest_path)
+    except Exception as err:
+        findings.append(Finding("warning", f"manifest read failed: {err}"))
+        return findings, []
+
+    if not manifest_path.exists():
+        findings.append(Finding("warning", f"mount manifest is missing: {manifest_path}"))
+        return findings, []
+
+    if not entries:
+        findings.append(Finding("warning", f"mount manifest is empty: {manifest_path}"))
+        return findings, []
+
+    findings.append(Finding("ok", f"mount manifest has {len(entries)} entries"))
+
+    for entry in entries:
+        try:
+            if entry.host_path.is_dir():
+                findings.append(
+                    Finding("ok", f"mount host path exists: {entry.name} -> {entry.host_path}")
+                )
+            else:
+                findings.append(
+                    Finding(
+                        "issue",
+                        f"mount host path is missing: {entry.name} -> {entry.host_path}",
+                    )
+                )
+        except Exception as err:
+            findings.append(Finding("issue", f"mount path check failed for {entry.name}: {err}"))
+
+    return findings, entries
+
+
+def _check_git_root_bridge(entries: list) -> list[Finding]:
+    """Check 7: Git-root bridge entry is recorded in the manifest."""
+    for entry in entries:
+        if entry.name.endswith("-git-root"):
+            return [Finding("ok", f"git-root bridge entry found: {entry.name}")]
+    return [Finding("issue", "git-root bridge entry missing from mount manifest")]
+
+
+def _check_packs(project: object, repo_root: Path) -> list[Finding]:
+    """Check 8: Each enabled pack has a corresponding .sh file."""
+    findings: list[Finding] = []
+    packs_dir = repo_root / ".tart" / "packs"
+
+    for pack_name in project.packs:  # type: ignore[union-attr]
+        pack_file = packs_dir / f"{pack_name}.sh"
+        try:
+            if pack_file.exists():
+                findings.append(Finding("ok", f"pack file exists: {pack_name} -> {pack_file}"))
+            else:
+                findings.append(
+                    Finding("issue", f"pack file is missing: {pack_name} -> {pack_file}")
+                )
+        except Exception as err:
+            findings.append(Finding("issue", f"pack file check failed for {pack_name}: {err}"))
+
+    return findings
+
+
+def _check_ssh_key(vm_name: str) -> list[Finding]:
+    """Check 9: SSH key file is present."""
+    try:
+        key_path = paths.ssh_key_path(vm_name)
+        if key_path.is_file():
+            return [Finding("ok", f"ssh key exists: {key_path}")]
+        return [Finding("warning", f"ssh key is missing: {key_path}")]
+    except Exception as err:
+        return [Finding("warning", f"ssh key check failed: {err}")]
+
+
+def _check_ssh_include(vm_name: str) -> list[Finding]:
+    """Check 10: User ~/.ssh/config includes the remo-tart managed config."""
+    try:
+        include_path = paths.ssh_include_path()
+        ssh_config = paths.user_ssh_config_path()
+        if not ssh_config.is_file():
+            return [Finding("warning", f"user ssh config missing: {ssh_config}")]
+        content = ssh_config.read_text()
+        if str(include_path) in content:
+            return [Finding("ok", f"ssh include present in {ssh_config}")]
+        return [
+            Finding(
+                "warning",
+                f"ssh include missing from {ssh_config}; expected: Include {include_path}",
+            )
+        ]
+    except Exception as err:
+        return [Finding("warning", f"ssh include check failed: {err}")]
+
+
+# ---------------------------------------------------------------------------
+# Aggregate
+# ---------------------------------------------------------------------------
+
+
+def run_all(vm_name: str, repo_root: Path) -> list[Finding]:
+    """Run all health checks and return the aggregated list of findings."""
+    findings: list[Finding] = []
+
+    # Check 1: config loadable
+    config_findings, project = _check_config(repo_root)
+    findings.extend(config_findings)
+
+    # Check 2: VM exists
+    vm_exists_findings, vm_exists = _check_vm_exists(vm_name)
+    findings.extend(vm_exists_findings)
+
+    # Check 3: VM running
+    vm_running_findings, vm_running = _check_vm_running(vm_name)
+    findings.extend(vm_running_findings)
+
+    # Check 4: launchd job
+    findings.extend(_check_launchd(vm_name, vm_running, vm_exists))
+
+    # Check 5 & 6: manifest exists, non-empty, host paths present
+    manifest_findings, entries = _check_manifest(vm_name)
+    findings.extend(manifest_findings)
+
+    # Check 7: git-root bridge (needs entries from manifest)
+    if entries:
+        findings.extend(_check_git_root_bridge(entries))
+    else:
+        findings.append(Finding("issue", "git-root bridge entry missing from mount manifest"))
+
+    # Checks 6-8 need the project config; skip if config load failed
+    if project is not None:
+        # Check 8: enabled packs have matching files
+        findings.extend(_check_packs(project, repo_root))
+
+    # Check 9: SSH key present
+    findings.extend(_check_ssh_key(vm_name))
+
+    # Check 10: SSH include present
+    findings.extend(_check_ssh_include(vm_name))
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render(findings: list[Finding]) -> str:
+    """Return a plain-text multi-line summary of findings."""
+    n_ok = sum(1 for f in findings if f.level == "ok")
+    n_warn = sum(1 for f in findings if f.level == "warning")
+    n_issue = sum(1 for f in findings if f.level == "issue")
+    total = len(findings)
+
+    status = "ok" if n_issue == 0 else "issues"
+
+    lines: list[str] = [
+        f"status: {status}",
+        f"checks: {total}, ok={n_ok}, warnings={n_warn}, issues={n_issue}",
+        "",
+    ]
+
+    for f in findings:
+        lines.append(f"[{f.level}] {f.message}")
+        if f.hint:
+            lines.append(f"  hint: {f.hint}")
+
+    return "\n".join(lines)
+
+
+def exit_code(findings: list[Finding]) -> int:
+    """Return 1 if any finding has level 'issue', else 0."""
+    return 1 if any(f.level == "issue" for f in findings) else 0

--- a/tools/remo-tart/src/remo_tart/launchd.py
+++ b/tools/remo-tart/src/remo_tart/launchd.py
@@ -1,0 +1,73 @@
+"""Wrap launchctl. Uses `launchctl submit` (in-memory, no plist file)."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+
+def _slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9.-]+", "-", name.lower()).strip("-")
+
+
+def label(vm_name: str) -> str:
+    return f"com.remo.tart.{_slug(vm_name)}"
+
+
+def build_submit_argv(
+    *,
+    label_str: str,
+    tart_args: list[str],
+    log_path: Path,
+) -> list[str]:
+    quoted = " ".join(shlex.quote(a) for a in tart_args)
+    shell_cmd = f"exec tart {quoted} > {shlex.quote(str(log_path))} 2>&1"
+    return [
+        "launchctl",
+        "submit",
+        "-l",
+        label_str,
+        "--",
+        "/bin/zsh",
+        "-lc",
+        shell_cmd,
+    ]
+
+
+def submit(label_str: str, tart_args: list[str], log_path: Path) -> None:
+    argv = build_submit_argv(label_str=label_str, tart_args=tart_args, log_path=log_path)
+    subprocess.run(argv, check=True)
+
+
+def remove(label_str: str) -> None:
+    subprocess.run(["launchctl", "remove", label_str], check=False)
+
+
+def _gui_uid() -> int:
+    return os.getuid()
+
+
+def job_present(label_str: str) -> bool:
+    target = f"gui/{_gui_uid()}/{label_str}"
+    result = subprocess.run(
+        ["launchctl", "print", target],
+        check=False,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def cleanup_stale(label_str: str, vm_running: bool) -> bool:
+    """If a launchd job is registered but the VM isn't actually running, remove it.
+
+    Returns True if cleanup happened.
+    """
+    if vm_running:
+        return False
+    if not job_present(label_str):
+        return False
+    remove(label_str)
+    return True

--- a/tools/remo-tart/src/remo_tart/mount.py
+++ b/tools/remo-tart/src/remo_tart/mount.py
@@ -1,0 +1,213 @@
+"""Mount manifest management, name derivation, and guest bridge script generation."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# Guest-side shared folder root (tart virtiofs mount point).
+_SHARED_ROOT = "/Volumes/My Shared Files"
+
+
+@dataclass(frozen=True)
+class MountEntry:
+    name: str
+    host_path: Path
+
+
+# ---------------------------------------------------------------------------
+# Manifest I/O
+# ---------------------------------------------------------------------------
+
+
+def manifest_read(path: Path) -> list[MountEntry]:
+    """Return entries from a manifest file, or [] if the file is absent."""
+    if not path.exists():
+        return []
+    entries: list[MountEntry] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        name, _, host = line.partition("\t")
+        if not name or not host:
+            continue
+        entries.append(MountEntry(name, Path(host)))
+    return entries
+
+
+def manifest_write(path: Path, entries: list[MountEntry]) -> None:
+    """Atomically write *entries* to *path*, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = "".join(f"{e.name}\t{e.host_path}\n" for e in entries)
+    fd, tmp = tempfile.mkstemp(dir=path.parent)
+    try:
+        os.write(fd, content.encode())
+        os.close(fd)
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def manifest_upsert(path: Path, entry: MountEntry) -> list[MountEntry]:
+    """Insert or replace *entry* (matched by name), persist, and return the new list."""
+    existing = manifest_read(path)
+    updated: list[MountEntry] = []
+    replaced = False
+    for e in existing:
+        if e.name == entry.name:
+            updated.append(entry)
+            replaced = True
+        else:
+            updated.append(e)
+    if not replaced:
+        updated.append(entry)
+    manifest_write(path, updated)
+    return updated
+
+
+def manifest_remove(path: Path, name: str) -> list[MountEntry]:
+    """Remove all entries with *name*, persist, and return the new list."""
+    existing = manifest_read(path)
+    kept = [e for e in existing if e.name != name]
+    manifest_write(path, kept)
+    return kept
+
+
+def manifest_prune_stale(path: Path) -> tuple[list[MountEntry], int]:
+    """Remove entries whose host_path does not exist on disk.
+
+    Returns ``(kept_entries, pruned_count)``.
+    """
+    existing = manifest_read(path)
+    kept = [e for e in existing if e.host_path.exists()]
+    pruned = len(existing) - len(kept)
+    manifest_write(path, kept)
+    return kept, pruned
+
+
+# ---------------------------------------------------------------------------
+# Mount name derivation
+# ---------------------------------------------------------------------------
+
+
+def _slugify(text: str) -> str:
+    """Lowercase, collapse non-alphanumeric runs to '-', strip leading/trailing '-'."""
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def mount_name_for_path(project_slug: str, host_path: Path) -> str:
+    """Derive a guest mount name from *host_path* following the slug rules.
+
+    1. Take the basename of *host_path*.
+    2. Slugify it.
+    3. If equal to *project_slug* → return as-is.
+    4. If already prefixed with ``<project_slug>-`` → return as-is.
+    5. Otherwise → return ``<project_slug>-<slug>``.
+    """
+    worktree_slug = _slugify(host_path.name)
+    if worktree_slug == project_slug:
+        return project_slug
+    if worktree_slug.startswith(f"{project_slug}-"):
+        return worktree_slug
+    return f"{project_slug}-{worktree_slug}"
+
+
+def git_root_bridge_entry(project_slug: str, git_root: Path) -> MountEntry:
+    """Return a ``MountEntry`` for the git-root bridge mount."""
+    return MountEntry(f"{project_slug}-git-root", git_root)
+
+
+def parse_mount_spec(project_slug: str, spec: str) -> MountEntry:
+    """Parse a mount spec of the form ``host[:name[:guest-root]]``.
+
+    * ``host`` is resolved to an absolute ``Path`` (but need not exist).
+    * ``name`` overrides the slug-derived name when provided.
+    * A third colon-separated component (guest-root) is accepted but ignored.
+    """
+    parts = spec.split(":")
+    host_path = Path(parts[0]).resolve()
+    if len(parts) >= 2 and parts[1]:
+        name = parts[1]
+    else:
+        name = mount_name_for_path(project_slug, host_path)
+    return MountEntry(name, host_path)
+
+
+# ---------------------------------------------------------------------------
+# Guest bridge script
+# ---------------------------------------------------------------------------
+
+
+def guest_bridge_script(entries: list[MountEntry], git_root_name: str) -> str:
+    """Return a bash script that wires up ``.git`` symlinks inside the guest.
+
+    For each entry in *entries* that is NOT the git-root bridge itself, the
+    script creates a symlink:
+
+        /Volumes/My Shared Files/<name>/.git
+            → /Volumes/My Shared Files/<git_root_name>
+
+    This mirrors the logic of ``remo_tart_guest_git_root_bridge_script`` in
+    ``scripts/tart/common.sh`` (lines 418-450).
+    """
+    lines: list[str] = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+    ]
+
+    git_root_mount = f"{_SHARED_ROOT}/{git_root_name}"
+
+    for entry in entries:
+        if entry.name == git_root_name:
+            continue
+
+        guest_git_root = f"{_SHARED_ROOT}/{entry.name}/.git"
+        guest_bridge_source = git_root_mount
+        guest_git_parent = f"{_SHARED_ROOT}/{entry.name}"
+
+        lines += [
+            f"guest_git_root={_shell_quote(guest_git_root)}",
+            f"guest_bridge_source={_shell_quote(guest_bridge_source)}",
+            f"guest_git_parent={_shell_quote(guest_git_parent)}",
+            'if [[ -L "${guest_git_parent}" ]]; then',
+            f'    printf "%s\\n" admin | sudo -S rm -f {_shell_quote(guest_git_parent)}',
+            "fi",
+            'if [[ -e "${guest_git_parent}" && ! -d "${guest_git_parent}" ]]; then',
+            '    echo "guest git parent exists and is not a directory: ${guest_git_parent}" >&2',
+            "    exit 1",
+            "fi",
+            'if [[ -L "${guest_git_root}" ]]; then',
+            '    current_target="$(readlink "${guest_git_root}")"',
+            '    if [[ "${current_target}" == "${guest_bridge_source}" ]]; then',
+            "        exit 0",
+            "    fi",
+            "fi",
+            'if [[ -e "${guest_git_root}" && ! -L "${guest_git_root}" ]]; then',
+            (
+                '    echo "guest git root bridge target already exists'
+                ' and is not a symlink: ${guest_git_root}" >&2'
+            ),
+            "    exit 1",
+            "fi",
+            f'printf "%s\\n" admin | sudo -S mkdir -p {_shell_quote(guest_git_parent)}',
+            (
+                f'printf "%s\\n" admin | sudo -S ln -sfn'
+                f" {_shell_quote(guest_bridge_source)} {_shell_quote(guest_git_root)}"
+            ),
+            "",
+        ]
+
+    return "\n".join(lines)
+
+
+def _shell_quote(s: str) -> str:
+    """Minimal single-quote shell escaping for paths."""
+    return "'" + s.replace("'", "'\\''") + "'"

--- a/tools/remo-tart/src/remo_tart/mount.py
+++ b/tools/remo-tart/src/remo_tart/mount.py
@@ -1,5 +1,9 @@
 """Mount manifest management, name derivation, and guest bridge script generation."""
 
+# The guest password defaults to the Cirrus Labs macOS image default ("admin").
+# Later tasks (see plan Task 8) will thread the real value from project config
+# into callers of guest_bridge_script.
+
 from __future__ import annotations
 
 import contextlib
@@ -74,6 +78,8 @@ def manifest_upsert(path: Path, entry: MountEntry) -> list[MountEntry]:
 
 def manifest_remove(path: Path, name: str) -> list[MountEntry]:
     """Remove all entries with *name*, persist, and return the new list."""
+    if not path.exists():
+        return []
     existing = manifest_read(path)
     kept = [e for e in existing if e.name != name]
     manifest_write(path, kept)
@@ -85,8 +91,10 @@ def manifest_prune_stale(path: Path) -> tuple[list[MountEntry], int]:
 
     Returns ``(kept_entries, pruned_count)``.
     """
+    if not path.exists():
+        return [], 0
     existing = manifest_read(path)
-    kept = [e for e in existing if e.host_path.exists()]
+    kept = [e for e in existing if e.host_path.is_dir()]
     pruned = len(existing) - len(kept)
     manifest_write(path, kept)
     return kept, pruned
@@ -145,7 +153,12 @@ def parse_mount_spec(project_slug: str, spec: str) -> MountEntry:
 # ---------------------------------------------------------------------------
 
 
-def guest_bridge_script(entries: list[MountEntry], git_root_name: str) -> str:
+def guest_bridge_script(
+    entries: list[MountEntry],
+    git_root_name: str,
+    *,
+    guest_password: str = "admin",
+) -> str:
     """Return a bash script that wires up ``.git`` symlinks inside the guest.
 
     For each entry in *entries* that is NOT the git-root bridge itself, the
@@ -178,7 +191,10 @@ def guest_bridge_script(entries: list[MountEntry], git_root_name: str) -> str:
             f"guest_bridge_source={_shell_quote(guest_bridge_source)}",
             f"guest_git_parent={_shell_quote(guest_git_parent)}",
             'if [[ -L "${guest_git_parent}" ]]; then',
-            f'    printf "%s\\n" admin | sudo -S rm -f {_shell_quote(guest_git_parent)}',
+            (
+                f'    printf "%s\\n" {_shell_quote(guest_password)}'
+                f" | sudo -S rm -f {_shell_quote(guest_git_parent)}"
+            ),
             "fi",
             'if [[ -e "${guest_git_parent}" && ! -d "${guest_git_parent}" ]]; then',
             '    echo "guest git parent exists and is not a directory: ${guest_git_parent}" >&2',
@@ -197,9 +213,12 @@ def guest_bridge_script(entries: list[MountEntry], git_root_name: str) -> str:
             ),
             "    exit 1",
             "fi",
-            f'printf "%s\\n" admin | sudo -S mkdir -p {_shell_quote(guest_git_parent)}',
             (
-                f'printf "%s\\n" admin | sudo -S ln -sfn'
+                f'printf "%s\\n" {_shell_quote(guest_password)}'
+                f" | sudo -S mkdir -p {_shell_quote(guest_git_parent)}"
+            ),
+            (
+                f'printf "%s\\n" {_shell_quote(guest_password)} | sudo -S ln -sfn'
                 f" {_shell_quote(guest_bridge_source)} {_shell_quote(guest_git_root)}"
             ),
             "",

--- a/tools/remo-tart/src/remo_tart/paths.py
+++ b/tools/remo-tart/src/remo_tart/paths.py
@@ -1,0 +1,34 @@
+"""Centralised on-disk paths. Pure — no I/O."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _config_root() -> Path:
+    return Path.home() / ".config" / "remo" / "tart"
+
+
+def state_dir(vm_name: str) -> Path:
+    del vm_name  # reserved; state dir is shared across VMs today
+    return _config_root()
+
+
+def mount_manifest_path(vm_name: str) -> Path:
+    return _config_root() / f"{vm_name}.mounts"
+
+
+def vm_log_path(vm_name: str) -> Path:
+    return _config_root() / f"{vm_name}.log"
+
+
+def ssh_include_path() -> Path:
+    return _config_root() / "ssh_config"
+
+
+def ssh_key_path(vm_name: str) -> Path:
+    return _config_root() / "ssh" / f"{vm_name}_ed25519"
+
+
+def user_ssh_config_path() -> Path:
+    return Path.home() / ".ssh" / "config"

--- a/tools/remo-tart/src/remo_tart/provision.py
+++ b/tools/remo-tart/src/remo_tart/provision.py
@@ -1,0 +1,109 @@
+"""Guest-side provisioning orchestrator.
+
+Builds a bash script that runs inside the tart VM to source each enabled
+pack, call its ``tart_pack_<name>_ensure`` function, run the project-level
+provision hook, and optionally run the verify-worktree hook.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+from remo_tart import vm
+from remo_tart.config import ProjectConfig
+from remo_tart.errors import RemoTartError
+from remo_tart.mount import MountEntry
+
+_SHARED_ROOT = "/Volumes/My Shared Files"
+
+
+def _always_quote(s: str) -> str:
+    """Always wrap *s* in double-quotes, escaping ``"`` and ``$`` inside."""
+    escaped = s.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$").replace("`", "\\`")
+    return f'"{escaped}"'
+
+
+def _primary_mount(mounts: list[MountEntry]) -> MountEntry:
+    """Return the first mount that is not the git-root bridge.
+
+    Raises :exc:`~remo_tart.errors.RemoTartError` if no such mount exists.
+    """
+    for entry in mounts:
+        if not entry.name.endswith("-git-root"):
+            return entry
+    raise RemoTartError(
+        "no primary mount found — all mounts are git-root bridges",
+        hint="add at least one worktree mount before calling provision",
+    )
+
+
+def build_guest_script(
+    project: ProjectConfig,
+    mounts: list[MountEntry],
+    packs_dir_guest: str,
+    *,
+    verify: bool,
+) -> str:
+    """Return a bash script the guest will run to provision itself."""
+    primary = _primary_mount(mounts)
+    primary_guest_path = f"{_SHARED_ROOT}/{primary.name}"
+
+    lines: list[str] = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+    ]
+
+    # Source each enabled pack
+    for pack in project.packs:
+        pack_path = f"{packs_dir_guest}/{pack}.sh"
+        lines.append(f"source {_always_quote(pack_path)}")
+
+    if project.packs:
+        lines.append("")
+
+    # Call the ensure function for each enabled pack
+    for pack in project.packs:
+        lines.append(f"tart_pack_{pack}_ensure")
+
+    if project.packs:
+        lines.append("")
+
+    # Run project-level provision hook
+    provision_path = f"{primary_guest_path}/.tart/provision.sh"
+    lines.append(f"bash {shlex.quote(provision_path)}")
+
+    # Optionally run verify-worktree
+    if verify:
+        lines.append("")
+        verify_path = f"{primary_guest_path}/.tart/verify-worktree.sh"
+        lines.append(f"bash {shlex.quote(verify_path)}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run_provision(
+    vm_name: str,
+    project: ProjectConfig,
+    mounts: list[MountEntry],
+    *,
+    verify: bool = True,
+) -> int:
+    """Ship the guest script via vm.exec_interactive, return exit code."""
+    packs_dir = _packs_dir_guest(mounts)
+    script = build_guest_script(project, mounts, packs_dir_guest=packs_dir, verify=verify)
+    return vm.exec_interactive(vm_name, ["bash", "-c", script])
+
+
+def _packs_dir_guest(mounts: list[MountEntry]) -> str:
+    """Derive the guest-side packs directory from the git-root bridge mount.
+
+    The packs dir lives under the git-root bridge at ``.tart/packs``.
+    Falls back to the primary mount if no git-root bridge exists.
+    """
+    for entry in mounts:
+        if entry.name.endswith("-git-root"):
+            return f"{_SHARED_ROOT}/{entry.name}/.tart/packs"
+    primary = _primary_mount(mounts)
+    return f"{_SHARED_ROOT}/{primary.name}/.tart/packs"

--- a/tools/remo-tart/src/remo_tart/ssh.py
+++ b/tools/remo-tart/src/remo_tart/ssh.py
@@ -1,0 +1,232 @@
+"""SSH config managed-block editor, alias helpers, and keypair management."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Marker templates
+# ---------------------------------------------------------------------------
+
+_BLOCK_BEGIN_TMPL = "# >>> remo tart managed: {vm_name}"
+_BLOCK_END_TMPL = "# <<< remo tart managed: {vm_name}"
+_INCLUDE_BEGIN = "# >>> remo tart include"
+_INCLUDE_END = "# <<< remo tart include"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def ssh_alias(vm_name: str) -> str:
+    """Return the SSH Host alias for *vm_name*: ``tart-<vm-name>``."""
+    return f"tart-{vm_name}"
+
+
+def remote_authority(vm_name: str, guest_user: str, ip: str) -> str:
+    """Return the VS Code remote authority string ``ssh-remote+<user>@<ip>``."""
+    return f"ssh-remote+{guest_user}@{ip}"
+
+
+def block_marker_pair(vm_name: str) -> tuple[str, str]:
+    """Return ``(begin_marker, end_marker)`` for the managed block of *vm_name*."""
+    return (
+        _BLOCK_BEGIN_TMPL.format(vm_name=vm_name),
+        _BLOCK_END_TMPL.format(vm_name=vm_name),
+    )
+
+
+def include_marker_pair() -> tuple[str, str]:
+    """Return ``(begin_marker, end_marker)`` for the include stanza."""
+    return _INCLUDE_BEGIN, _INCLUDE_END
+
+
+def managed_block(vm_name: str, guest_user: str, key_path: Path) -> str:
+    """Return the SSH Host block body for *vm_name* (without begin/end markers).
+
+    Pass the result to :func:`upsert_managed_block`, which wraps it with the
+    appropriate markers.  The block mirrors ``remo_tart_ssh_config_block`` in
+    ``common.sh``.
+    """
+    alias = ssh_alias(vm_name)
+    proxy_cmd = f"tart exec -i {vm_name} /usr/bin/nc 127.0.0.1 22"
+    lines = [
+        f"Host {alias}",
+        "  HostName 127.0.0.1",
+        f"  User {guest_user}",
+        f"  IdentityFile {key_path}",
+        "  IdentitiesOnly yes",
+        "  StrictHostKeyChecking no",
+        "  UserKnownHostsFile /dev/null",
+        "  ServerAliveInterval 30",
+        "  ServerAliveCountMax 3",
+        f"  ProxyCommand {proxy_cmd}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Config file I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent)
+    try:
+        os.write(fd, content.encode())
+        os.close(fd)
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def _read_text(path: Path) -> str:
+    """Return file contents or empty string if file is absent."""
+    if not path.exists():
+        return ""
+    return path.read_text()
+
+
+def _remove_block(text: str, begin: str, end: str) -> str:
+    """Strip the managed block (begin…end inclusive) from *text* using regex."""
+    pattern = re.escape(begin) + r".*?" + re.escape(end) + r"\n?"
+    return re.sub(pattern, "", text, flags=re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# Managed block upsert / remove
+# ---------------------------------------------------------------------------
+
+
+def upsert_managed_block(config_path: Path, vm_name: str, block_text: str) -> None:
+    """Insert or replace the managed block for *vm_name* in *config_path*.
+
+    *block_text* is the block body (without markers).  This function wraps it
+    with the begin/end marker pair.  If the file already has a block for
+    *vm_name*, it is replaced.  Otherwise the wrapped block is appended.
+    The write is atomic.
+    """
+    begin, end = block_marker_pair(vm_name)
+    existing = _read_text(config_path)
+
+    base = _remove_block(existing, begin, end) if begin in existing else existing
+
+    # Ensure a newline separator before appending (if content is non-empty).
+    if base and not base.endswith("\n"):
+        base += "\n"
+
+    wrapped = f"{begin}\n{block_text}{end}\n"
+    new_content = base + wrapped
+
+    _atomic_write(config_path, new_content)
+
+
+def remove_managed_block(config_path: Path, vm_name: str) -> None:
+    """Remove the managed block for *vm_name* from *config_path*.
+
+    No-op if the file does not exist or the block is absent.
+    """
+    if not config_path.exists():
+        return
+
+    begin, end = block_marker_pair(vm_name)
+    existing = config_path.read_text()
+
+    if begin not in existing:
+        return
+
+    new_content = _remove_block(existing, begin, end)
+    _atomic_write(config_path, new_content)
+
+
+# ---------------------------------------------------------------------------
+# Include directive helpers
+# ---------------------------------------------------------------------------
+
+
+def ensure_include_in_user_config(user_config: Path, include_path: Path) -> None:
+    """Prepend an Include stanza for *include_path* into *user_config*.
+
+    Idempotent: if the Include directive is already present, does nothing.
+    """
+    include_line = f"Include {include_path}"
+    existing = _read_text(user_config)
+
+    if include_line in existing:
+        return
+
+    # Build the include block and prepend it.
+    block = f"{_INCLUDE_BEGIN}\n{include_line}\n{_INCLUDE_END}\n"
+    # Strip any pre-existing include marker block first (in case it refers to a
+    # different path — mirrors bash behaviour which removes then re-prepends).
+    new_content = _remove_block(existing, _INCLUDE_BEGIN, _INCLUDE_END)
+    new_content = block + new_content
+
+    _atomic_write(user_config, new_content)
+
+
+def remove_include_from_user_config(user_config: Path, include_path: Path) -> None:
+    """Remove the Include stanza for *include_path* from *user_config*.
+
+    No-op if the file does not exist or the stanza is absent.
+    """
+    if not user_config.exists():
+        return
+
+    existing = user_config.read_text()
+    new_content = _remove_block(existing, _INCLUDE_BEGIN, _INCLUDE_END)
+    _atomic_write(user_config, new_content)
+
+
+# ---------------------------------------------------------------------------
+# Keypair management
+# ---------------------------------------------------------------------------
+
+
+def generate_keypair(key_path: Path) -> None:
+    """Generate an ed25519 keypair at *key_path* if it does not already exist.
+
+    Idempotent: if both ``key_path`` and ``key_path.pub`` exist and are
+    non-empty, returns immediately without regenerating the key.
+    """
+    pub_path = key_path.with_suffix(key_path.suffix + ".pub")
+    if (
+        key_path.is_file()
+        and pub_path.is_file()
+        and key_path.stat().st_size > 0
+        and pub_path.stat().st_size > 0
+    ):
+        return
+
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            "ssh-keygen",
+            "-t",
+            "ed25519",
+            "-N",
+            "",
+            "-f",
+            str(key_path),
+            "-C",
+            f"remo-tart-{key_path.stem}",
+        ],
+        check=True,
+    )
+
+
+def public_key(key_path: Path) -> str:
+    """Return the contents of ``<key_path>.pub``, stripped of trailing whitespace."""
+    pub_path = key_path.with_suffix(key_path.suffix + ".pub")
+    return pub_path.read_text().strip()

--- a/tools/remo-tart/src/remo_tart/ssh.py
+++ b/tools/remo-tart/src/remo_tart/ssh.py
@@ -13,10 +13,10 @@ from pathlib import Path
 # Marker templates
 # ---------------------------------------------------------------------------
 
-_BLOCK_BEGIN_TMPL = "# >>> remo tart managed: {vm_name}"
-_BLOCK_END_TMPL = "# <<< remo tart managed: {vm_name}"
-_INCLUDE_BEGIN = "# >>> remo tart include"
-_INCLUDE_END = "# <<< remo tart include"
+_BLOCK_BEGIN_TMPL = "# >>> remo tart managed: {vm_name} >>>"
+_BLOCK_END_TMPL = "# <<< remo tart managed: {vm_name} <<<"
+_INCLUDE_BEGIN = "# >>> remo tart include >>>"
+_INCLUDE_END = "# <<< remo tart include <<<"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/remo-tart/src/remo_tart/state.py
+++ b/tools/remo-tart/src/remo_tart/state.py
@@ -1,0 +1,33 @@
+"""Pure state-machine for the `remo-tart up` command."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+@dataclass(frozen=True)
+class VmState:
+    exists: bool
+    running: bool
+    mount_matches: bool
+
+
+class Action(Enum):
+    CREATE = auto()
+    UPDATE_MOUNT_AND_RESTART = auto()
+    START = auto()
+    ATTACH_MOUNT_AND_START = auto()
+    NOTHING = auto()
+
+
+def decide(state: VmState) -> list[Action]:
+    if not state.exists:
+        return [Action.CREATE]
+    if state.running and state.mount_matches:
+        return [Action.NOTHING]
+    if state.running and not state.mount_matches:
+        return [Action.UPDATE_MOUNT_AND_RESTART]
+    if not state.running and state.mount_matches:
+        return [Action.START]
+    return [Action.ATTACH_MOUNT_AND_START]

--- a/tools/remo-tart/src/remo_tart/status.py
+++ b/tools/remo-tart/src/remo_tart/status.py
@@ -1,0 +1,147 @@
+"""Aggregate VM/mount/SSH/launchd state into a dict; render human or JSON."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from remo_tart import launchd, vm
+from remo_tart.mount import manifest_read
+from remo_tart.paths import (
+    mount_manifest_path,
+    ssh_include_path,
+    ssh_key_path,
+    user_ssh_config_path,
+)
+
+
+def collect(vm_name: str, repo_root: Path, active_worktree: Path) -> dict:  # type: ignore[type-arg]
+    """Aggregate state for *vm_name* into a flat dict.
+
+    Parameters
+    ----------
+    vm_name:
+        The tart VM name (e.g. ``"remo-dev"``).
+    repo_root:
+        Root of the git repository (used to locate the SSH git-root entry).
+    active_worktree:
+        The currently active worktree path; used to determine *selected* mount.
+    """
+    # --- VM section ----------------------------------------------------------
+    vm_exists = vm.exists(vm_name)
+    vm_running = vm.is_running(vm_name) if vm_exists else False
+    vm_ip = vm.ip_address(vm_name) if vm_running else None
+
+    # --- Launchd section -----------------------------------------------------
+    launchd_label = launchd.label(vm_name)
+    launchd_present = launchd.job_present(launchd_label)
+
+    # --- Mounts section ------------------------------------------------------
+    manifest_path = mount_manifest_path(vm_name)
+    entries = manifest_read(manifest_path)
+
+    resolved_worktree = active_worktree.resolve()
+    selected: str | None = None
+    for entry in entries:
+        try:
+            if entry.host_path.resolve() == resolved_worktree:
+                selected = entry.name
+                break
+        except OSError:
+            pass
+
+    git_root_present = any(e.name.endswith("-git-root") for e in entries)
+
+    entries_list = [{"name": e.name, "host_path": str(e.host_path)} for e in entries]
+
+    # --- SSH section ---------------------------------------------------------
+    inc_path = ssh_include_path()
+    key_path = ssh_key_path(vm_name)
+    key_present = key_path.is_file()
+
+    user_cfg = user_ssh_config_path()
+    include_present = False
+    if user_cfg.exists():
+        try:
+            content = user_cfg.read_text()
+            include_present = str(inc_path) in content
+        except OSError:
+            pass
+
+    return {
+        "vm": {
+            "name": vm_name,
+            "exists": vm_exists,
+            "running": vm_running,
+            "ip": vm_ip,
+        },
+        "launchd": {
+            "label": launchd_label,
+            "job_present": launchd_present,
+        },
+        "mounts": {
+            "manifest_path": str(manifest_path),
+            "count": len(entries),
+            "entries": entries_list,
+            "selected": selected,
+            "git_root_present": git_root_present,
+        },
+        "ssh": {
+            "include_path": str(inc_path),
+            "key_path": str(key_path),
+            "key_present": key_present,
+            "include_present_in_user_config": include_present,
+        },
+    }
+
+
+def _fmt(value: object) -> str:
+    """Format a scalar value for human output."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def render_human(data: dict) -> str:  # type: ignore[type-arg]
+    """Return a multi-line human-readable representation of *data*.
+
+    Sections are rendered in fixed order: vm, launchd, mounts, ssh.
+    Booleans are lowercase; ``None`` becomes ``null``.
+    """
+    lines: list[str] = []
+
+    # vm section
+    vm_sec = data["vm"]
+    lines.append("vm:")
+    for key in ("name", "exists", "running", "ip"):
+        lines.append(f"  {key}={_fmt(vm_sec[key])}")
+
+    # launchd section
+    ld_sec = data["launchd"]
+    lines.append("launchd:")
+    for key in ("label", "job_present"):
+        lines.append(f"  {key}={_fmt(ld_sec[key])}")
+
+    # mounts section
+    mnt_sec = data["mounts"]
+    lines.append("mounts:")
+    for key in ("manifest_path", "count", "selected", "git_root_present"):
+        lines.append(f"  {key}={_fmt(mnt_sec[key])}")
+    lines.append("  entries:")
+    for entry in mnt_sec["entries"]:
+        lines.append(f"    {entry['name']}={entry['host_path']}")
+
+    # ssh section
+    ssh_sec = data["ssh"]
+    lines.append("ssh:")
+    for key in ("include_path", "key_path", "key_present", "include_present_in_user_config"):
+        lines.append(f"  {key}={_fmt(ssh_sec[key])}")
+
+    return "\n".join(lines)
+
+
+def render_json(data: dict) -> str:  # type: ignore[type-arg]
+    """Return a pretty-printed JSON string for *data*."""
+    return json.dumps(data, indent=2)

--- a/tools/remo-tart/src/remo_tart/vm.py
+++ b/tools/remo-tart/src/remo_tart/vm.py
@@ -1,0 +1,210 @@
+"""Tart CLI subprocess wrappers.
+
+Every function that shells out to ``tart`` lives here.  All other modules that
+need VM state or mutation import from this module rather than calling
+``subprocess`` directly.
+
+Memory note: ``tart set --memory`` expects megabytes, so ``memory_gb`` is
+multiplied by 1024 before being passed to the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from remo_tart.errors import RemoTartError
+from remo_tart.mount import MountEntry
+
+# ---------------------------------------------------------------------------
+# State queries
+# ---------------------------------------------------------------------------
+
+
+def list_names() -> list[str]:
+    """Return names of all locally known tart VMs (``tart list --quiet``)."""
+    result = subprocess.run(
+        ["tart", "list", "--quiet"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def exists(name: str) -> bool:
+    """Return ``True`` if *name* appears in the local tart VM list."""
+    return name in list_names()
+
+
+def get_state(name: str) -> dict:  # type: ignore[type-arg]
+    """Return the parsed JSON state dict for *name* (``tart get <name> --format json``).
+
+    Raises :exc:`~remo_tart.errors.RemoTartError` if the tart call fails.
+    """
+    result = subprocess.run(
+        ["tart", "get", name, "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RemoTartError(
+            f"tart get failed for VM '{name}': {result.stderr.strip()}",
+            hint=f"Run 'tart list' to see available VMs, or 'tart run {name}' to start it.",
+        )
+    return json.loads(result.stdout)  # type: ignore[no-any-return]
+
+
+def is_running(name: str) -> bool:
+    """Return ``True`` if *name* is in the ``running`` state.
+
+    Handles both ``"State"`` and ``"state"`` keys and case-insensitive values,
+    because tart has been inconsistent across versions.
+    """
+    state = get_state(name)
+    # Accept either capitalisation of the key
+    raw_value = state.get("State") or state.get("state") or ""
+    return raw_value.lower() == "running"
+
+
+def ip_address(name: str) -> str | None:
+    """Return the IP address for *name*, or ``None`` if it cannot be determined.
+
+    First tries ``tart ip <name>``.  If that fails, falls back to
+    ``tart exec <name> -- /usr/bin/ipconfig getifaddr en0`` (mirroring the
+    ``remo_tart_vm_connect_ip`` logic in ``common.sh:658-688``).
+    """
+    result = subprocess.run(
+        ["tart", "ip", name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        ip = result.stdout.strip()
+        if ip:
+            return ip
+
+    # Fallback: ask the guest directly
+    fallback = subprocess.run(
+        ["tart", "exec", name, "--", "/usr/bin/ipconfig", "getifaddr", "en0"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if fallback.returncode == 0:
+        ip = fallback.stdout.strip()
+        if ip:
+            return ip
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Mutation helpers (clone / delete / configure)
+# ---------------------------------------------------------------------------
+
+
+def create(name: str, from_image: str) -> None:
+    """Clone *from_image* into a new local VM named *name*."""
+    subprocess.run(
+        ["tart", "clone", from_image, name],
+        check=True,
+    )
+
+
+def delete(name: str) -> None:
+    """Delete the local VM named *name*."""
+    subprocess.run(
+        ["tart", "delete", name],
+        check=True,
+    )
+
+
+def set_resources(name: str, cpu: int, memory_gb: int) -> None:
+    """Configure CPU count and RAM for *name*.
+
+    ``memory_gb`` is converted to megabytes (``* 1024``) before being passed
+    to ``tart set --memory``, which expects MB.
+    """
+    subprocess.run(
+        [
+            "tart",
+            "set",
+            name,
+            "--cpu",
+            str(cpu),
+            "--memory",
+            str(memory_gb * 1024),
+        ],
+        check=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exec wrappers
+# ---------------------------------------------------------------------------
+
+
+def exec_capture(name: str, argv: list[str]) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    """Run *argv* inside *name* and capture stdout/stderr.
+
+    Returns the :class:`subprocess.CompletedProcess` without raising on
+    non-zero exit codes — callers are responsible for checking ``returncode``.
+    """
+    return subprocess.run(
+        ["tart", "exec", name, "--", *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def exec_interactive(name: str, argv: list[str]) -> int:
+    """Run *argv* inside *name* with an inherited tty.
+
+    Returns the exit code of the remote command.
+    """
+    result = subprocess.run(
+        ["tart", "exec", name, "--", *argv],
+        check=False,
+    )
+    return result.returncode
+
+
+# ---------------------------------------------------------------------------
+# Pure build helper (no subprocess — safe to call from launchd submitter)
+# ---------------------------------------------------------------------------
+
+
+def build_run_args(name: str, network: str, mounts: list[MountEntry]) -> list[str]:
+    """Return the ``tart run`` argv list for *name* (without the ``tart`` prefix).
+
+    This is a **pure function** — it never shells out.  The launchd submitter
+    calls it to compose the run command before handing it to ``launchctl``.
+
+    Network strings:
+    - ``"shared"``        → ``["--net-shared"]``
+    - ``"softnet"``       → ``["--net-softnet"]``
+    - ``"bridged:<iface>"`` → ``["--net-bridged", "<iface>"]``
+
+    Each :class:`~remo_tart.mount.MountEntry` adds
+    ``["--dir", "<name>:<host_path>:rw"]``.
+    """
+    args: list[str] = ["run", name]
+
+    # Network
+    if network == "shared":
+        args.append("--net-shared")
+    elif network == "softnet":
+        args.append("--net-softnet")
+    elif network.startswith("bridged:"):
+        iface = network[len("bridged:") :]
+        args += ["--net-bridged", iface]
+
+    # Mounts
+    for entry in mounts:
+        args += ["--dir", f"{entry.name}:{entry.host_path}:rw"]
+
+    return args

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -8,8 +8,9 @@ and the SSH config updated.  Ported from:
 
 from __future__ import annotations
 
+import shlex
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from remo_tart import launchd, ssh, vm
@@ -46,8 +47,9 @@ _WAIT_ATTEMPTS = 90  # maximum polling attempts (~3 minutes total)
 
 @dataclass(frozen=True)
 class AttachOutcome:
-    actions: list[Action]
-    manifest: list[MountEntry] = field(default_factory=list)
+    actions: tuple[Action, ...]
+    manifest: tuple[MountEntry, ...]
+    primary: MountEntry
 
 
 def ensure_attached(
@@ -107,7 +109,11 @@ def ensure_attached(
 
     # Step 6: Return outcome with the final manifest.
     final_manifest = manifest_read(manifest_path)
-    return AttachOutcome(actions=actions, manifest=final_manifest)
+    return AttachOutcome(
+        actions=tuple(actions),
+        manifest=tuple(final_manifest),
+        primary=primary_entry,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -159,12 +165,20 @@ def _action_create(
 ) -> None:
     """Create VM from base image, configure resources, and start it."""
     name = project.vm.name
+    label_str = launchd.label(name)
+
+    # Truncate log to avoid confusion with stale output
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("")
+
+    # Remove any stale launchd registration for this label to avoid submit failure
+    launchd.remove(label_str)
+
     vm.create(name, project.vm.base_image)
     vm.set_resources(name, project.vm.cpu, project.vm.memory_gb)
     tart_args = vm.build_run_args(name, project.vm.network, mounts)
-    label_str = launchd.label(name)
     launchd.submit(label_str, tart_args, log_path)
-    _wait_for_running(name)
+    _wait_for_guest_exec(name)
 
 
 def _action_update_mount_and_restart(
@@ -177,9 +191,14 @@ def _action_update_mount_and_restart(
     label_str = launchd.label(name)
     launchd.remove(label_str)
     _wait_for_stopped(name)
+    # Also wait for launchctl to actually drop the label, to avoid submit conflict
+    for _ in range(30):
+        if not launchd.job_present(label_str):
+            break
+        time.sleep(1)
     tart_args = vm.build_run_args(name, project.vm.network, mounts)
     launchd.submit(label_str, tart_args, log_path)
-    _wait_for_running(name)
+    _wait_for_guest_exec(name)
 
 
 def _action_start(
@@ -190,9 +209,17 @@ def _action_start(
     """Submit the VM to launchd and wait for it to be running."""
     name = project.vm.name
     label_str = launchd.label(name)
+
+    # Truncate log to avoid confusion with stale output
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("")
+
+    # Remove any stale launchd registration for this label to avoid submit failure
+    launchd.remove(label_str)
+
     tart_args = vm.build_run_args(name, project.vm.network, mounts)
     launchd.submit(label_str, tart_args, log_path)
-    _wait_for_running(name)
+    _wait_for_guest_exec(name)
 
 
 def _action_attach_mount_and_start(
@@ -201,7 +228,19 @@ def _action_attach_mount_and_start(
     log_path: Path,
 ) -> None:
     """Mount is already upserted before state read; just submit and wait."""
-    _action_start(project, mounts, log_path)
+    name = project.vm.name
+    label_str = launchd.label(name)
+
+    # Truncate log to avoid confusion with stale output
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("")
+
+    # Remove any stale launchd registration for this label to avoid submit failure
+    launchd.remove(label_str)
+
+    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    launchd.submit(label_str, tart_args, log_path)
+    _wait_for_guest_exec(name)
 
 
 def _action_nothing(project: ProjectConfig) -> None:
@@ -211,6 +250,17 @@ def _action_nothing(project: ProjectConfig) -> None:
     console.print(
         f"[dim]VM '{project.vm.name}' is already running with the correct mount. "
         "Nothing to do.[/dim]"
+    )
+
+
+def _build_inject_command(pub: str) -> str:
+    """Build a shell command to idempotently inject a public key into authorized_keys."""
+    quoted_pub = shlex.quote(pub)
+    return (
+        "mkdir -p ~/.ssh && chmod 700 ~/.ssh && "
+        f"grep -Fqx -- {quoted_pub} ~/.ssh/authorized_keys 2>/dev/null || "
+        f"printf '%s\\n' {quoted_pub} >> ~/.ssh/authorized_keys && "
+        "chmod 600 ~/.ssh/authorized_keys"
     )
 
 
@@ -230,14 +280,15 @@ def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
     user_config = user_ssh_config_path()
     ssh.ensure_include_in_user_config(user_config, include_path)
 
-    # 4. Inject the public key into the guest's authorized_keys.
-    pub_key = ssh.public_key(key_path)
-    inject_cmd = (
-        "mkdir -p ~/.ssh && "
-        f"echo '{pub_key}' >> ~/.ssh/authorized_keys && "
-        "chmod 600 ~/.ssh/authorized_keys"
-    )
-    vm.exec_capture(name, ["sh", "-c", inject_cmd])
+    # 4. Inject the public key into the guest's authorized_keys (idempotent).
+    pub = ssh.public_key(key_path)
+    inject_cmd = _build_inject_command(pub)
+    result = vm.exec_capture(name, ["sh", "-c", inject_cmd])
+    if result.returncode != 0:
+        raise RemoTartError(
+            f"failed to install ssh public key into guest (exit {result.returncode})",
+            hint=f"check {vm_log_path(name)} and ensure the VM is fully booted",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -245,15 +296,24 @@ def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _wait_for_running(name: str) -> None:
-    """Poll until the VM is running, or raise RemoTartError on timeout."""
-    for _ in range(_WAIT_ATTEMPTS):
-        if vm.is_running(name):
+def _wait_for_guest_exec(vm_name: str, *, attempts: int = 90, interval: float = 2.0) -> None:
+    """Poll `tart exec true` until success. Raises RemoTartError on timeout.
+
+    This is stricter than `vm.is_running` — it waits for the guest agent to
+    respond, which is what downstream SSH key injection actually needs.
+    """
+    for _ in range(attempts):
+        # Quick readiness check — `tart exec <name> -- /usr/bin/true`
+        if not vm.is_running(vm_name):
+            time.sleep(interval)
+            continue
+        result = vm.exec_capture(vm_name, ["/usr/bin/true"])
+        if result.returncode == 0:
             return
-        time.sleep(_WAIT_INTERVAL)
+        time.sleep(interval)
     raise RemoTartError(
-        f"timeout waiting for VM '{name}' to start",
-        hint=f"check ~/.config/remo/tart/{name}.log",
+        f"timeout waiting for VM '{vm_name}' to be ready for exec",
+        hint=f"check {vm_log_path(vm_name)}",
     )
 
 
@@ -265,5 +325,5 @@ def _wait_for_stopped(name: str) -> None:
         time.sleep(_WAIT_INTERVAL)
     raise RemoTartError(
         f"timeout waiting for VM '{name}' to stop",
-        hint=f"check ~/.config/remo/tart/{name}.log",
+        hint=f"check {vm_log_path(name)}",
     )

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -1,0 +1,269 @@
+"""Worktree attach/boot orchestrator.
+
+Given a worktree path, make the VM running with the right mounts attached
+and the SSH config updated.  Ported from:
+  - scripts/tart/use-worktree-dev-vm.sh
+  - scripts/tart/create-dev-vm.sh
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from remo_tart import launchd, ssh, vm
+from remo_tart.config import ProjectConfig
+from remo_tart.errors import RemoTartError
+from remo_tart.mount import (
+    MountEntry,
+    git_root_bridge_entry,
+    manifest_prune_stale,
+    manifest_read,
+    manifest_upsert,
+    mount_name_for_path,
+)
+from remo_tart.paths import (
+    mount_manifest_path,
+    ssh_include_path,
+    ssh_key_path,
+    user_ssh_config_path,
+    vm_log_path,
+)
+from remo_tart.state import Action, VmState, decide
+
+# TODO(pr3): move to config
+_GUEST_USER = "admin"
+
+_WAIT_INTERVAL = 2  # seconds between polls
+_WAIT_ATTEMPTS = 90  # maximum polling attempts (~3 minutes total)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AttachOutcome:
+    actions: list[Action]
+    manifest: list[MountEntry] = field(default_factory=list)
+
+
+def ensure_attached(
+    repo_root: Path,
+    project: ProjectConfig,
+    worktree_host_path: Path,
+) -> AttachOutcome:
+    """Make the VM running with the given worktree attached; idempotent."""
+    vm_name = project.vm.name
+    manifest_path = mount_manifest_path(vm_name)
+    log_path = vm_log_path(vm_name)
+    key_path = ssh_key_path(vm_name)
+
+    # Step 1: Snapshot pre-upsert state, prune stale entries, then upsert the
+    # primary + git-root bridge entries.
+    pre_upsert = manifest_read(manifest_path)
+    worktree_already_present = any(
+        e.host_path.resolve() == worktree_host_path.resolve() for e in pre_upsert
+    )
+
+    manifest_prune_stale(manifest_path)
+    target = _target_manifest(project, repo_root, worktree_host_path)
+
+    primary_entry = MountEntry(
+        name=mount_name_for_path(project.slug, worktree_host_path),
+        host_path=worktree_host_path,
+    )
+    bridge_entry = git_root_bridge_entry(project.slug, repo_root / ".git")
+    manifest_upsert(manifest_path, primary_entry)
+    manifest_upsert(manifest_path, bridge_entry)
+
+    # Step 2: Read VM state.  Pass worktree_already_present so _read_state can
+    # use the pre-upsert view when deciding mount_matches (the running VM loaded
+    # the OLD manifest at boot — a restart is needed if the mount wasn't there).
+    vm_state = _read_state(project, manifest_path, worktree_host_path, worktree_already_present)
+
+    # Step 3: Decide actions from the state machine.
+    actions = decide(vm_state)
+
+    # Step 4: Dispatch.
+    mounts = target
+    for action in actions:
+        if action == Action.CREATE:
+            _action_create(project, mounts, log_path, key_path)
+        elif action == Action.UPDATE_MOUNT_AND_RESTART:
+            _action_update_mount_and_restart(project, mounts, log_path)
+        elif action == Action.START:
+            _action_start(project, mounts, log_path)
+        elif action == Action.ATTACH_MOUNT_AND_START:
+            _action_attach_mount_and_start(project, mounts, log_path)
+        elif action == Action.NOTHING:
+            _action_nothing(project)
+
+    # Step 5: Configure SSH for all actions except NOTHING.
+    if actions != [Action.NOTHING]:
+        _configure_ssh(project, key_path)
+
+    # Step 6: Return outcome with the final manifest.
+    final_manifest = manifest_read(manifest_path)
+    return AttachOutcome(actions=actions, manifest=final_manifest)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (patchable by tests)
+# ---------------------------------------------------------------------------
+
+
+def _read_state(
+    project: ProjectConfig,
+    manifest_path: Path,
+    worktree: Path,
+    worktree_already_present: bool = False,
+) -> VmState:
+    """Read current VM and manifest state.
+
+    ``worktree_already_present`` reflects whether the worktree path was in the
+    manifest BEFORE the current upsert.  A running VM loaded the old manifest at
+    boot, so ``mount_matches`` is True only when the path was already present —
+    meaning no restart is required to expose the mount inside the guest.
+    """
+    name = project.vm.name
+    exists = vm.exists(name)
+    running = exists and vm.is_running(name)
+    # A running VM has the OLD manifest loaded; we need a restart only when the
+    # worktree was not already mounted at boot time.
+    mount_matches = running and worktree_already_present
+    return VmState(exists=exists, running=running, mount_matches=mount_matches)
+
+
+def _target_manifest(
+    project: ProjectConfig,
+    repo_root: Path,
+    worktree: Path,
+) -> list[MountEntry]:
+    """Build the target mount list: primary worktree + git-root bridge."""
+    primary = MountEntry(
+        name=mount_name_for_path(project.slug, worktree),
+        host_path=worktree,
+    )
+    bridge = git_root_bridge_entry(project.slug, repo_root / ".git")
+    return [primary, bridge]
+
+
+def _action_create(
+    project: ProjectConfig,
+    mounts: list[MountEntry],
+    log_path: Path,
+    ssh_key_path: Path,
+) -> None:
+    """Create VM from base image, configure resources, and start it."""
+    name = project.vm.name
+    vm.create(name, project.vm.base_image)
+    vm.set_resources(name, project.vm.cpu, project.vm.memory_gb)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    label_str = launchd.label(name)
+    launchd.submit(label_str, tart_args, log_path)
+    _wait_for_running(name)
+
+
+def _action_update_mount_and_restart(
+    project: ProjectConfig,
+    mounts: list[MountEntry],
+    log_path: Path,
+) -> None:
+    """Stop the VM, update mounts, and restart."""
+    name = project.vm.name
+    label_str = launchd.label(name)
+    launchd.remove(label_str)
+    _wait_for_stopped(name)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    launchd.submit(label_str, tart_args, log_path)
+    _wait_for_running(name)
+
+
+def _action_start(
+    project: ProjectConfig,
+    mounts: list[MountEntry],
+    log_path: Path,
+) -> None:
+    """Submit the VM to launchd and wait for it to be running."""
+    name = project.vm.name
+    label_str = launchd.label(name)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    launchd.submit(label_str, tart_args, log_path)
+    _wait_for_running(name)
+
+
+def _action_attach_mount_and_start(
+    project: ProjectConfig,
+    mounts: list[MountEntry],
+    log_path: Path,
+) -> None:
+    """Mount is already upserted before state read; just submit and wait."""
+    _action_start(project, mounts, log_path)
+
+
+def _action_nothing(project: ProjectConfig) -> None:
+    """No-op — VM is already running with the correct mount."""
+    from remo_tart.console import console
+
+    console.print(
+        f"[dim]VM '{project.vm.name}' is already running with the correct mount. "
+        "Nothing to do.[/dim]"
+    )
+
+
+def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
+    """Configure SSH keypair, managed block, include directive, and authorized keys."""
+    name = project.vm.name
+
+    # 1. Generate keypair (idempotent).
+    ssh.generate_keypair(key_path)
+
+    # 2. Build and upsert the managed SSH config block.
+    block = ssh.managed_block(name, _GUEST_USER, key_path)
+    include_path = ssh_include_path()
+    ssh.upsert_managed_block(include_path, name, block)
+
+    # 3. Ensure the include directive is in the user's SSH config.
+    user_config = user_ssh_config_path()
+    ssh.ensure_include_in_user_config(user_config, include_path)
+
+    # 4. Inject the public key into the guest's authorized_keys.
+    pub_key = ssh.public_key(key_path)
+    inject_cmd = (
+        "mkdir -p ~/.ssh && "
+        f"echo '{pub_key}' >> ~/.ssh/authorized_keys && "
+        "chmod 600 ~/.ssh/authorized_keys"
+    )
+    vm.exec_capture(name, ["sh", "-c", inject_cmd])
+
+
+# ---------------------------------------------------------------------------
+# Wait helpers
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_running(name: str) -> None:
+    """Poll until the VM is running, or raise RemoTartError on timeout."""
+    for _ in range(_WAIT_ATTEMPTS):
+        if vm.is_running(name):
+            return
+        time.sleep(_WAIT_INTERVAL)
+    raise RemoTartError(
+        f"timeout waiting for VM '{name}' to start",
+        hint=f"check ~/.config/remo/tart/{name}.log",
+    )
+
+
+def _wait_for_stopped(name: str) -> None:
+    """Poll until the VM has stopped, or raise RemoTartError on timeout."""
+    for _ in range(_WAIT_ATTEMPTS):
+        if not vm.is_running(name):
+            return
+        time.sleep(_WAIT_INTERVAL)
+    raise RemoTartError(
+        f"timeout waiting for VM '{name}' to stop",
+        hint=f"check ~/.config/remo/tart/{name}.log",
+    )

--- a/tools/remo-tart/tests/test_cli.py
+++ b/tools/remo-tart/tests/test_cli.py
@@ -1,5 +1,8 @@
+"""Tests for cli.py — PR 2 (native Python modules, no bash_dispatch)."""
+
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +10,52 @@ from click.testing import CliRunner
 
 from remo_tart import __version__
 from remo_tart.cli import main
+from remo_tart.state import Action
+
+# ---------------------------------------------------------------------------
+# Minimal valid project.toml used by all subcommand tests
+# ---------------------------------------------------------------------------
+
+_VALID_TOML = """
+[project]
+slug = "remo"
+
+[vm]
+name = "remo-dev"
+base_image = "img"
+cpu = 1
+memory_gb = 1
+network = "shared"
+
+[packs]
+enabled = ["ios"]
+
+[scripts]
+provision = ".tart/provision.sh"
+verify_worktree = ".tart/verify-worktree.sh"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # The "repo" needs scripts/tart/ to satisfy find_repo_root
+    (tmp_path / "scripts" / "tart").mkdir(parents=True)
+    # And a valid project.toml
+    (tmp_path / ".tart").mkdir()
+    (tmp_path / ".tart" / "project.toml").write_text(_VALID_TOML)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests preserved from PR 1 (structure-level)
+# ---------------------------------------------------------------------------
 
 
 def test_help_does_not_crash() -> None:
@@ -41,107 +90,392 @@ def test_all_subcommands_appear_in_help() -> None:
         assert cmd in result.output, f"{cmd} missing from --help"
 
 
-@pytest.fixture
-def mock_dispatch() -> MagicMock:
-    with patch("remo_tart.cli.bash_dispatch") as m:
-        m.return_value = MagicMock(returncode=0)
-        yield m
+def test_run_returns_child_exit_code(monkeypatch: pytest.MonkeyPatch, fake_repo: Path) -> None:
+    from remo_tart.cli import _run
+
+    with (
+        patch("remo_tart.cli._status.collect") as mock_collect,
+        patch("remo_tart.cli._status.render_human") as mock_render,
+    ):
+        mock_collect.return_value = {}
+        mock_render.return_value = "vm: ..."
+        monkeypatch.setattr("sys.argv", ["remo-tart", "status"])
+        code = _run()
+    assert code == 0
 
 
-def test_use_forwards_to_use_worktree_script(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["use"])
-    assert result.exit_code == 0
-    mock_dispatch.assert_called_once()
-    assert mock_dispatch.call_args.args[0] == "use-worktree-dev-vm.sh"
+# ---------------------------------------------------------------------------
+# up subcommand
+# ---------------------------------------------------------------------------
 
 
-def test_connect_forwards_mode(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["connect", "vscode"])
-    assert result.exit_code == 0
-    mock_dispatch.assert_called_once()
-    assert mock_dispatch.call_args.args[0] == "connect-dev-vm.sh"
-    assert "vscode" in mock_dispatch.call_args.args[1]
+@patch("remo_tart.cli._connect.connect_vscode")
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_up_vscode_invokes_worktree_then_connect(
+    ensure: MagicMock,
+    connect_vscode: MagicMock,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.mount import MountEntry
 
-
-def test_connect_defaults_to_cli(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["connect"])
-    assert result.exit_code == 0
-    assert "cli" in mock_dispatch.call_args.args[1]
-
-
-def test_status_forwards(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["status"])
-    assert result.exit_code == 0
-    assert mock_dispatch.call_args.args[0] == "status-dev-vm.sh"
-
-
-def test_doctor_forwards(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["doctor"])
-    assert result.exit_code == 0
-    assert mock_dispatch.call_args.args[0] == "doctor-dev-vm.sh"
-
-
-def test_ssh_forwards_with_passthrough_args(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["ssh", "--", "uname", "-a"])
-    assert result.exit_code == 0
-    assert mock_dispatch.call_args.args[0] == "ssh-dev-vm.sh"
-    assert "uname" in mock_dispatch.call_args.args[1]
-    assert "-a" in mock_dispatch.call_args.args[1]
-
-
-def test_destroy_forwards_force_flag(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["destroy", "--force"])
-    assert result.exit_code == 0
-    assert mock_dispatch.call_args.args[0] == "destroy-dev-vm.sh"
-    assert "--force" in mock_dispatch.call_args.args[1]
-
-
-def test_clean_worktree_forwards_path(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["clean-worktree", "/tmp/foo"])
-    assert result.exit_code == 0
-    assert mock_dispatch.call_args.args[0] == "clean-worktree-dev-vm.sh"
-    assert "/tmp/foo" in mock_dispatch.call_args.args[1]
-
-
-def test_bootstrap_forwards(mock_dispatch: MagicMock) -> None:
-    runner = CliRunner()
-    result = runner.invoke(main, ["bootstrap"])
-    assert result.exit_code == 0
-    assert mock_dispatch.call_args.args[0] == "bootstrap-dev-vm.sh"
-
-
-def test_up_forwards_to_use_and_connect(mock_dispatch: MagicMock) -> None:
+    primary = MountEntry(name="remo-feat", host_path=fake_repo)
+    ensure.return_value = MagicMock(
+        primary=primary,
+        actions=(Action.CREATE,),
+    )
+    connect_vscode.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["up", "vscode"])
     assert result.exit_code == 0
-    # up is approximated in PR 1 as use-worktree + connect
-    calls = [c.args[0] for c in mock_dispatch.call_args_list]
-    assert "use-worktree-dev-vm.sh" in calls
-    assert "connect-dev-vm.sh" in calls
+    ensure.assert_called_once()
+    connect_vscode.assert_called_once()
 
 
-def test_up_stops_on_use_failure(mock_dispatch: MagicMock) -> None:
-    mock_dispatch.side_effect = [MagicMock(returncode=1)]
+@patch("remo_tart.cli._connect.connect_cli")
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_up_cli_mode_calls_connect_cli(
+    ensure: MagicMock,
+    connect_cli: MagicMock,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.mount import MountEntry
+
+    primary = MountEntry(name="remo-main", host_path=fake_repo)
+    ensure.return_value = MagicMock(primary=primary, actions=(Action.NOTHING,))
+    connect_cli.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["up"])
-    assert result.exit_code == 1
-    # only use-worktree was called; connect skipped
-    assert mock_dispatch.call_count == 1
+    assert result.exit_code == 0
+    connect_cli.assert_called_once()
 
 
-def test_run_returns_child_exit_code(
-    monkeypatch: pytest.MonkeyPatch, mock_dispatch: MagicMock
+@patch("remo_tart.cli._connect.connect_cursor")
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_up_cursor_mode_calls_connect_cursor(
+    ensure: MagicMock,
+    connect_cursor: MagicMock,
+    fake_repo: Path,
 ) -> None:
-    from remo_tart.cli import _run
+    from remo_tart.mount import MountEntry
 
-    mock_dispatch.return_value = MagicMock(returncode=42)
-    monkeypatch.setattr("sys.argv", ["remo-tart", "status"])
-    assert _run() == 42
+    primary = MountEntry(name="remo-main", host_path=fake_repo)
+    ensure.return_value = MagicMock(primary=primary, actions=(Action.NOTHING,))
+    connect_cursor.return_value = 0
+    runner = CliRunner()
+    result = runner.invoke(main, ["up", "cursor"])
+    assert result.exit_code == 0
+    connect_cursor.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# use subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_use_calls_ensure_attached(ensure: MagicMock, fake_repo: Path) -> None:
+    from remo_tart.mount import MountEntry
+
+    primary = MountEntry(name="remo-main", host_path=fake_repo)
+    ensure.return_value = MagicMock(primary=primary, actions=(Action.NOTHING,))
+    runner = CliRunner()
+    result = runner.invoke(main, ["use"])
+    assert result.exit_code == 0
+    ensure.assert_called_once()
+
+
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_use_with_explicit_path(ensure: MagicMock, fake_repo: Path) -> None:
+    from remo_tart.mount import MountEntry
+
+    primary = MountEntry(name="remo-wt", host_path=fake_repo)
+    ensure.return_value = MagicMock(primary=primary, actions=(Action.ATTACH_MOUNT_AND_START,))
+    runner = CliRunner()
+    result = runner.invoke(main, ["use", str(fake_repo)])
+    assert result.exit_code == 0
+    ensure.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# start subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli.launchd.submit")
+@patch("remo_tart.cli.launchd.remove")
+@patch("remo_tart.cli.vm.build_run_args")
+@patch("remo_tart.cli.vm.exists")
+def test_start_submits_to_launchd(
+    vm_exists: MagicMock,
+    build_args: MagicMock,
+    launchd_remove: MagicMock,
+    launchd_submit: MagicMock,
+    fake_repo: Path,
+) -> None:
+    vm_exists.return_value = True
+    build_args.return_value = ["run", "remo-dev"]
+    runner = CliRunner()
+    result = runner.invoke(main, ["start"])
+    assert result.exit_code == 0
+    launchd_remove.assert_called_once()
+    launchd_submit.assert_called_once()
+
+
+@patch("remo_tart.cli.vm.exists")
+def test_start_raises_when_vm_missing(vm_exists: MagicMock, fake_repo: Path) -> None:
+    vm_exists.return_value = False
+    runner = CliRunner()
+    result = runner.invoke(main, ["start"])
+    assert result.exit_code == 1
+    assert "vm does not exist" in result.output or result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# connect subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli._connect.connect_vscode")
+@patch("remo_tart.cli.vm.is_running")
+@patch("remo_tart.cli.mount.manifest_read")
+def test_connect_vscode_when_running(
+    manifest_read: MagicMock,
+    is_running: MagicMock,
+    connect_vscode: MagicMock,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.mount import MountEntry
+
+    is_running.return_value = True
+    primary = MountEntry(name="remo-main", host_path=fake_repo)
+    manifest_read.return_value = [primary]
+    connect_vscode.return_value = 0
+    runner = CliRunner()
+    result = runner.invoke(main, ["connect", "vscode"])
+    assert result.exit_code == 0
+    connect_vscode.assert_called_once()
+
+
+@patch("remo_tart.cli.vm.is_running")
+def test_connect_errors_when_not_running(is_running: MagicMock, fake_repo: Path) -> None:
+    is_running.return_value = False
+    runner = CliRunner()
+    result = runner.invoke(main, ["connect", "vscode"])
+    assert result.exit_code == 1
+    assert "not running" in result.output or result.exit_code == 1
+
+
+@patch("remo_tart.cli._connect.connect_cli")
+@patch("remo_tart.cli.vm.is_running")
+@patch("remo_tart.cli.mount.manifest_read")
+def test_connect_cli_default_mode(
+    manifest_read: MagicMock,
+    is_running: MagicMock,
+    connect_cli: MagicMock,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.mount import MountEntry
+
+    is_running.return_value = True
+    primary = MountEntry(name="remo-main", host_path=fake_repo)
+    manifest_read.return_value = [primary]
+    connect_cli.return_value = 0
+    runner = CliRunner()
+    result = runner.invoke(main, ["connect"])
+    assert result.exit_code == 0
+    connect_cli.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# status subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli._status.collect")
+@patch("remo_tart.cli._status.render_human")
+def test_status_calls_collect_and_renders(
+    render_human: MagicMock,
+    collect: MagicMock,
+    fake_repo: Path,
+) -> None:
+    collect.return_value = {"vm": {}}
+    render_human.return_value = "vm:\n  name=remo-dev"
+    runner = CliRunner()
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    collect.assert_called_once()
+    render_human.assert_called_once()
+
+
+@patch("remo_tart.cli._status.collect")
+@patch("remo_tart.cli._status.render_json")
+def test_status_json_flag(
+    render_json: MagicMock,
+    collect: MagicMock,
+    fake_repo: Path,
+) -> None:
+    collect.return_value = {"vm": {}}
+    render_json.return_value = '{"vm": {}}'
+    runner = CliRunner()
+    result = runner.invoke(main, ["status", "--json"])
+    assert result.exit_code == 0
+    collect.assert_called_once()
+    render_json.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# doctor subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli._doctor.run_all")
+@patch("remo_tart.cli._doctor.render")
+@patch("remo_tart.cli._doctor.exit_code")
+def test_doctor_runs_all_checks(
+    exit_code: MagicMock,
+    render: MagicMock,
+    run_all: MagicMock,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.doctor import Finding
+
+    findings = [Finding("ok", "all good")]
+    run_all.return_value = findings
+    render.return_value = "status: ok"
+    exit_code.return_value = 0
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor"])
+    assert result.exit_code == 0
+    run_all.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ssh subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli.vm.exec_interactive")
+@patch("remo_tart.cli.vm.is_running")
+def test_ssh_forwards_args_when_running(
+    is_running: MagicMock,
+    exec_interactive: MagicMock,
+    fake_repo: Path,
+) -> None:
+    is_running.return_value = True
+    exec_interactive.return_value = 0
+    runner = CliRunner()
+    result = runner.invoke(main, ["ssh", "--", "uname", "-a"])
+    assert result.exit_code == 0
+    exec_interactive.assert_called_once()
+    call_args = exec_interactive.call_args
+    assert "uname" in call_args[0][1]
+    assert "-a" in call_args[0][1]
+
+
+@patch("remo_tart.cli.vm.is_running")
+def test_ssh_errors_when_not_running(is_running: MagicMock, fake_repo: Path) -> None:
+    is_running.return_value = False
+    runner = CliRunner()
+    result = runner.invoke(main, ["ssh"])
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# destroy subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli._ssh.remove_managed_block")
+@patch("remo_tart.cli._ssh.remove_include_from_user_config")
+@patch("remo_tart.cli.vm.exists")
+@patch("remo_tart.cli.vm.delete")
+@patch("remo_tart.cli.launchd.remove")
+def test_destroy_force_skips_prompt(
+    launchd_remove: MagicMock,
+    vm_delete: MagicMock,
+    vm_exists: MagicMock,
+    remove_include: MagicMock,
+    remove_block: MagicMock,
+    fake_repo: Path,
+) -> None:
+    vm_exists.return_value = True
+    runner = CliRunner()
+    result = runner.invoke(main, ["destroy", "--force"])
+    assert result.exit_code == 0
+    launchd_remove.assert_called_once()
+    vm_delete.assert_called_once()
+    remove_block.assert_called_once()
+    remove_include.assert_called_once()
+
+
+@patch("remo_tart.cli._ssh.remove_managed_block")
+@patch("remo_tart.cli._ssh.remove_include_from_user_config")
+@patch("remo_tart.cli.vm.exists")
+@patch("remo_tart.cli.vm.delete")
+@patch("remo_tart.cli.launchd.remove")
+def test_destroy_prompt_abort_exits_nonzero(
+    launchd_remove: MagicMock,
+    vm_delete: MagicMock,
+    vm_exists: MagicMock,
+    remove_include: MagicMock,
+    remove_block: MagicMock,
+    fake_repo: Path,
+) -> None:
+    vm_exists.return_value = True
+    runner = CliRunner()
+    result = runner.invoke(main, ["destroy"], input="n\n")
+    assert result.exit_code != 0
+    vm_delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# clean-worktree subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli.mount.manifest_remove")
+def test_clean_worktree_removes_from_manifest(
+    manifest_remove: MagicMock,
+    fake_repo: Path,
+) -> None:
+    manifest_remove.return_value = []
+    runner = CliRunner()
+    result = runner.invoke(main, ["clean-worktree", str(fake_repo)])
+    assert result.exit_code == 0
+    manifest_remove.assert_called_once()
+
+
+@patch("remo_tart.cli.mount.manifest_remove")
+def test_clean_worktree_defaults_to_cwd(
+    manifest_remove: MagicMock,
+    fake_repo: Path,
+) -> None:
+    manifest_remove.return_value = []
+    runner = CliRunner()
+    result = runner.invoke(main, ["clean-worktree"])
+    assert result.exit_code == 0
+    manifest_remove.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# bootstrap subcommand
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli._connect.connect_cli")
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_bootstrap_calls_ensure_attached_and_connect_cli(
+    ensure: MagicMock,
+    connect_cli: MagicMock,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.mount import MountEntry
+
+    primary = MountEntry(name="remo-main", host_path=fake_repo)
+    ensure.return_value = MagicMock(primary=primary, actions=(Action.CREATE,))
+    connect_cli.return_value = 0
+    runner = CliRunner()
+    result = runner.invoke(main, ["bootstrap"])
+    assert result.exit_code == 0
+    ensure.assert_called_once()
+    connect_cli.assert_called_once()

--- a/tools/remo-tart/tests/test_cli.py
+++ b/tools/remo-tart/tests/test_cli.py
@@ -286,6 +286,23 @@ def test_connect_cli_default_mode(
     connect_cli.assert_called_once()
 
 
+@patch("remo_tart.cli.vm.is_running", return_value=True)
+@patch("remo_tart.cli.mount.manifest_read", return_value=[])
+def test_connect_raises_when_manifest_is_empty(
+    manifest_read: MagicMock,
+    is_running: MagicMock,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.errors import RemoTartError
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["connect", "vscode"])
+    assert result.exit_code == 1
+    # RemoTartError propagates as the exception when Rich console swallows output
+    assert isinstance(result.exception, RemoTartError)
+    assert "no mounts" in str(result.exception).lower()
+
+
 # ---------------------------------------------------------------------------
 # status subcommand
 # ---------------------------------------------------------------------------
@@ -378,6 +395,22 @@ def test_ssh_errors_when_not_running(is_running: MagicMock, fake_repo: Path) -> 
     runner = CliRunner()
     result = runner.invoke(main, ["ssh"])
     assert result.exit_code == 1
+
+
+@patch("remo_tart.cli.vm.exec_interactive")
+@patch("remo_tart.cli.vm.is_running", return_value=True)
+def test_ssh_with_no_args_defaults_to_interactive_zsh(
+    is_running: MagicMock,
+    exec_interactive: MagicMock,
+    fake_repo: Path,
+) -> None:
+    exec_interactive.return_value = 0
+    runner = CliRunner()
+    result = runner.invoke(main, ["ssh"])
+    assert result.exit_code == 0
+    exec_interactive.assert_called_once()
+    (_called_vm, called_argv) = exec_interactive.call_args[0]
+    assert called_argv == ["/bin/zsh", "-l"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/remo-tart/tests/test_config.py
+++ b/tools/remo-tart/tests/test_config.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from remo_tart.config import (
+    ProjectConfig,
+    legacy_project_sh_present,
+    load,
+)
+from remo_tart.errors import RemoTartError
+
+
+def _write_toml(repo: Path, content: str) -> None:
+    tart_dir = repo / ".tart"
+    tart_dir.mkdir(exist_ok=True)
+    (tart_dir / "project.toml").write_text(content)
+
+
+def _valid_toml() -> str:
+    return textwrap.dedent(
+        """
+        [project]
+        slug = "remo"
+
+        [vm]
+        name = "remo-dev"
+        base_image = "ghcr.io/cirruslabs/macos-tahoe-xcode:26"
+        cpu = 6
+        memory_gb = 12
+        network = "bridged:en0"
+
+        [packs]
+        enabled = ["ios", "rust"]
+
+        [scripts]
+        provision = ".tart/provision.sh"
+        verify_worktree = ".tart/verify-worktree.sh"
+        """
+    ).strip()
+
+
+def test_load_valid_config(tmp_path: Path) -> None:
+    _write_toml(tmp_path, _valid_toml())
+    cfg = load(tmp_path)
+    assert isinstance(cfg, ProjectConfig)
+    assert cfg.slug == "remo"
+    assert cfg.vm.name == "remo-dev"
+    assert cfg.vm.cpu == 6
+    assert cfg.vm.memory_gb == 12
+    assert cfg.vm.network == "bridged:en0"
+    assert cfg.packs == ["ios", "rust"]
+    assert cfg.scripts.provision == ".tart/provision.sh"
+
+
+def test_load_missing_toml_with_legacy_sh_raises_with_hint(tmp_path: Path) -> None:
+    (tmp_path / ".tart").mkdir()
+    (tmp_path / ".tart" / "project.sh").write_text("# legacy")
+    with pytest.raises(RemoTartError) as excinfo:
+        load(tmp_path)
+    assert "project.toml" in str(excinfo.value)
+    assert excinfo.value.hint is not None
+    assert "project.toml" in excinfo.value.hint
+
+
+def test_load_missing_toml_and_sh_raises(tmp_path: Path) -> None:
+    (tmp_path / ".tart").mkdir()
+    with pytest.raises(RemoTartError) as excinfo:
+        load(tmp_path)
+    assert excinfo.value.hint is not None
+
+
+def test_load_invalid_toml_raises_with_hint(tmp_path: Path) -> None:
+    _write_toml(tmp_path, "not = valid = toml")
+    with pytest.raises(RemoTartError) as excinfo:
+        load(tmp_path)
+    assert excinfo.value.hint is not None
+
+
+def test_load_missing_required_field_raises(tmp_path: Path) -> None:
+    incomplete = textwrap.dedent(
+        """
+        [project]
+        slug = "x"
+
+        [vm]
+        name = "x"
+        base_image = "x"
+        cpu = 1
+        memory_gb = 1
+        """
+    ).strip()
+    _write_toml(tmp_path, incomplete)
+    with pytest.raises(RemoTartError):
+        load(tmp_path)
+
+
+def test_legacy_project_sh_present(tmp_path: Path) -> None:
+    assert legacy_project_sh_present(tmp_path) is False
+    (tmp_path / ".tart").mkdir()
+    (tmp_path / ".tart" / "project.sh").write_text("#")
+    assert legacy_project_sh_present(tmp_path) is True
+
+
+def test_load_prefers_toml_when_both_present(tmp_path: Path) -> None:
+    _write_toml(tmp_path, _valid_toml())
+    (tmp_path / ".tart" / "project.sh").write_text("# legacy")
+    cfg = load(tmp_path)
+    assert cfg.slug == "remo"

--- a/tools/remo-tart/tests/test_connect.py
+++ b/tools/remo-tart/tests/test_connect.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from remo_tart.connect import connect_cli, connect_cursor, connect_vscode
+from remo_tart.mount import MountEntry
+
+
+@patch("subprocess.run")
+def test_connect_cli_runs_ssh_with_alias(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0)
+    assert connect_cli("remo-dev", "admin") == 0
+    (called_argv,) = run.call_args[0]
+    assert called_argv == ["ssh", "tart-remo-dev"]
+
+
+@patch("subprocess.run")
+def test_connect_cli_propagates_nonzero(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=130)
+    assert connect_cli("remo-dev", "admin") == 130
+
+
+@patch("subprocess.run")
+def test_connect_vscode_default_reuses_window(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0)
+    mount = MountEntry("remo-feat", Path("/r"))
+    connect_vscode("remo-dev", "admin", mount)
+    (called_argv,) = run.call_args[0]
+    assert called_argv[0] == "code"
+    assert "--folder-uri" in called_argv
+    idx = called_argv.index("--folder-uri")
+    uri = called_argv[idx + 1]
+    assert uri == "vscode-remote://ssh-remote+tart-remo-dev/Volumes/My Shared Files/remo-feat"
+    assert "--reuse-window" in called_argv
+    assert "--new-window" not in called_argv
+
+
+@patch("subprocess.run")
+def test_connect_vscode_new_window(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0)
+    mount = MountEntry("remo-feat", Path("/r"))
+    connect_vscode("remo-dev", "admin", mount, new_window=True)
+    (called_argv,) = run.call_args[0]
+    assert "--new-window" in called_argv
+    assert "--reuse-window" not in called_argv
+
+
+@patch("subprocess.run")
+def test_connect_cursor_uses_cursor_binary(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0)
+    mount = MountEntry("remo-feat", Path("/r"))
+    connect_cursor("remo-dev", "admin", mount)
+    (called_argv,) = run.call_args[0]
+    assert called_argv[0] == "cursor"
+    # Same URI as vscode (cursor accepts vscode-remote://)
+    idx = called_argv.index("--folder-uri")
+    uri = called_argv[idx + 1]
+    assert uri.startswith("vscode-remote://ssh-remote+tart-remo-dev/")
+
+
+@patch("subprocess.run")
+def test_connect_vscode_propagates_returncode(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=2)
+    mount = MountEntry("remo-feat", Path("/r"))
+    assert connect_vscode("remo-dev", "admin", mount) == 2

--- a/tools/remo-tart/tests/test_doctor.py
+++ b/tools/remo-tart/tests/test_doctor.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from remo_tart.config import ProjectConfig, ScriptsConfig, VmConfig
+from remo_tart.doctor import Finding, exit_code, render, run_all
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def _cfg() -> ProjectConfig:
+    return ProjectConfig(
+        slug="remo",
+        vm=VmConfig(
+            name="remo-dev",
+            base_image="img",
+            cpu=1,
+            memory_gb=1,
+            network="shared",
+        ),
+        packs=["ios", "rust"],
+        scripts=ScriptsConfig(
+            provision=".tart/provision.sh",
+            verify_worktree=".tart/verify-worktree.sh",
+        ),
+    )
+
+
+def test_finding_dataclass() -> None:
+    f = Finding(level="ok", message="all good")
+    assert f.hint is None
+    f2 = Finding(level="issue", message="boom", hint="do X")
+    assert f2.hint == "do X"
+
+
+def test_exit_code_returns_1_on_issue() -> None:
+    findings = [
+        Finding("ok", "good"),
+        Finding("warning", "meh"),
+        Finding("issue", "broken"),
+    ]
+    assert exit_code(findings) == 1
+
+
+def test_exit_code_returns_0_on_no_issues() -> None:
+    findings = [Finding("ok", "good"), Finding("warning", "meh")]
+    assert exit_code(findings) == 0
+
+
+def test_render_includes_status_summary() -> None:
+    findings = [
+        Finding("ok", "vm exists"),
+        Finding("warning", "vm not running"),
+        Finding("issue", "manifest missing"),
+    ]
+    text = render(findings)
+    assert "status:" in text
+    assert "issues" in text  # because we have an issue
+    assert "ok=1" in text
+    assert "warnings=1" in text
+    assert "issues=1" in text
+
+
+def test_render_includes_hint_when_present() -> None:
+    findings = [Finding("issue", "manifest missing", hint="run remo-tart up")]
+    text = render(findings)
+    assert "hint: run remo-tart up" in text
+
+
+def test_render_no_issues_says_ok() -> None:
+    findings = [Finding("ok", "all checks pass")]
+    text = render(findings)
+    assert "status: ok" in text
+
+
+@patch("remo_tart.doctor.config.load")
+@patch("remo_tart.doctor.vm.exists", return_value=False)
+@patch("remo_tart.doctor.vm.is_running", return_value=False)
+@patch("remo_tart.doctor.launchd.job_present", return_value=False)
+def test_run_all_with_missing_vm(
+    job_present: MagicMock,
+    is_running: MagicMock,
+    exists: MagicMock,
+    load: MagicMock,
+    fake_home: Path,
+    tmp_path: Path,
+) -> None:
+    load.return_value = _cfg()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    findings = run_all("remo-dev", repo)
+    levels = [f.level for f in findings]
+    assert "issue" in levels  # VM missing
+    msgs = " ".join(f.message for f in findings)
+    assert "remo-dev" in msgs
+
+
+@patch("remo_tart.doctor.config.load")
+@patch("remo_tart.doctor.vm.exists", return_value=True)
+@patch("remo_tart.doctor.vm.is_running", return_value=True)
+@patch("remo_tart.doctor.launchd.job_present", return_value=True)
+def test_run_all_healthy_vm_no_manifest_yields_warning(
+    job_present: MagicMock,
+    is_running: MagicMock,
+    exists: MagicMock,
+    load: MagicMock,
+    fake_home: Path,
+    tmp_path: Path,
+) -> None:
+    load.return_value = _cfg()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    findings = run_all("remo-dev", repo)
+    # VM checks pass but no manifest yet → warning
+    levels = [f.level for f in findings]
+    assert "warning" in levels
+
+
+def test_run_all_handles_config_load_failure(fake_home: Path, tmp_path: Path) -> None:
+    """If project.toml is missing, run_all should still return findings, not crash."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # No .tart/ directory at all → config.load will raise
+    findings = run_all("remo-dev", repo)
+    levels = [f.level for f in findings]
+    # Config-loading failure should produce an issue
+    assert "issue" in levels

--- a/tools/remo-tart/tests/test_launchd.py
+++ b/tools/remo-tart/tests/test_launchd.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from remo_tart.launchd import build_submit_argv, label
+
+
+def test_label_uses_slug() -> None:
+    assert label("remo-dev") == "com.remo.tart.remo-dev"
+
+
+def test_label_slugifies_uppercase() -> None:
+    assert label("Remo-Dev") == "com.remo.tart.remo-dev"
+
+
+def test_build_submit_argv_produces_expected_shape(tmp_path: Path) -> None:
+    log = tmp_path / "remo-dev.log"
+    argv = build_submit_argv(
+        label_str="com.remo.tart.remo-dev",
+        tart_args=["run", "remo-dev", "--net-bridged", "en0"],
+        log_path=log,
+    )
+    # ["launchctl", "submit", "-l", label, "--", "/bin/zsh", "-lc", "exec tart run ... > log 2>&1"]
+    assert argv[0:4] == ["launchctl", "submit", "-l", "com.remo.tart.remo-dev"]
+    assert argv[4] == "--"
+    assert argv[5:7] == ["/bin/zsh", "-lc"]
+    assert "exec tart run remo-dev --net-bridged en0" in argv[7]
+    assert f"> {log}" in argv[7]
+    assert "2>&1" in argv[7]
+
+
+def test_job_present_true_when_launchctl_prints(tmp_path: Path) -> None:
+    from remo_tart.launchd import job_present
+
+    with patch("subprocess.run") as run:
+        run.return_value.returncode = 0
+        assert job_present("com.remo.tart.remo-dev") is True
+
+
+def test_job_present_false_when_launchctl_fails(tmp_path: Path) -> None:
+    from remo_tart.launchd import job_present
+
+    with patch("subprocess.run") as run:
+        run.return_value.returncode = 1
+        assert job_present("com.remo.tart.remo-dev") is False

--- a/tools/remo-tart/tests/test_mount.py
+++ b/tools/remo-tart/tests/test_mount.py
@@ -146,3 +146,49 @@ def test_guest_bridge_script_contains_expected_markers() -> None:
     assert "set -euo pipefail" in script
     assert "My Shared Files/remo-git-root" in script
     assert "remo-feat" in script
+
+
+def test_guest_bridge_script_excludes_git_root_entry() -> None:
+    script = guest_bridge_script(
+        [
+            MountEntry("remo-git-root", Path("/r/.git")),
+            MountEntry("remo-feat", Path("/r")),
+        ],
+        git_root_name="remo-git-root",
+    )
+    # The git-root bridge itself must not be symlinked to its own .git subdir.
+    assert "My Shared Files/remo-git-root/.git" not in script
+    assert "My Shared Files/remo-feat/.git" in script
+
+
+def test_manifest_prune_does_not_create_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "mounts"
+    kept, pruned = manifest_prune_stale(path)
+    assert (kept, pruned) == ([], 0)
+    assert not path.exists()
+
+
+def test_manifest_remove_does_not_create_missing_file(tmp_path: Path) -> None:
+    path = tmp_path / "mounts"
+    after = manifest_remove(path, "anything")
+    assert after == []
+    assert not path.exists()
+
+
+def test_manifest_prune_treats_file_as_stale(tmp_path: Path) -> None:
+    # A "directory" that's actually a regular file should be pruned (bash -d semantics).
+    not_dir = tmp_path / "file"
+    not_dir.write_text("x")
+    live = tmp_path / "live"
+    live.mkdir()
+    path = tmp_path / "mounts"
+    manifest_write(
+        path,
+        [
+            MountEntry("live", live),
+            MountEntry("a-file", not_dir),
+        ],
+    )
+    kept, pruned = manifest_prune_stale(path)
+    assert pruned == 1
+    assert [e.name for e in kept] == ["live"]

--- a/tools/remo-tart/tests/test_mount.py
+++ b/tools/remo-tart/tests/test_mount.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from remo_tart.mount import (
+    MountEntry,
+    git_root_bridge_entry,
+    guest_bridge_script,
+    manifest_prune_stale,
+    manifest_read,
+    manifest_remove,
+    manifest_upsert,
+    manifest_write,
+    mount_name_for_path,
+    parse_mount_spec,
+)
+
+
+def test_manifest_roundtrip(tmp_path: Path) -> None:
+    path = tmp_path / "remo-dev.mounts"
+    entries = [
+        MountEntry("remo", Path("/tmp/remo")),
+        MountEntry("remo-git-root", Path("/tmp/remo/.git")),
+    ]
+    manifest_write(path, entries)
+    assert manifest_read(path) == entries
+
+
+def test_manifest_read_missing_returns_empty(tmp_path: Path) -> None:
+    assert manifest_read(tmp_path / "nope.mounts") == []
+
+
+def test_manifest_read_tolerates_blank_lines(tmp_path: Path) -> None:
+    path = tmp_path / "mounts"
+    path.write_text("\nremo\t/tmp/remo\n\n")
+    assert manifest_read(path) == [MountEntry("remo", Path("/tmp/remo"))]
+
+
+def test_manifest_upsert_replaces_by_name(tmp_path: Path) -> None:
+    path = tmp_path / "mounts"
+    manifest_write(path, [MountEntry("remo", Path("/old"))])
+    after = manifest_upsert(path, MountEntry("remo", Path("/new")))
+    assert after == [MountEntry("remo", Path("/new"))]
+    assert manifest_read(path) == after
+
+
+def test_manifest_upsert_preserves_order_and_appends_new(tmp_path: Path) -> None:
+    path = tmp_path / "mounts"
+    manifest_write(
+        path,
+        [
+            MountEntry("a", Path("/a")),
+            MountEntry("b", Path("/b")),
+        ],
+    )
+    after = manifest_upsert(path, MountEntry("c", Path("/c")))
+    assert [e.name for e in after] == ["a", "b", "c"]
+
+
+def test_manifest_remove(tmp_path: Path) -> None:
+    path = tmp_path / "mounts"
+    manifest_write(
+        path,
+        [
+            MountEntry("a", Path("/a")),
+            MountEntry("b", Path("/b")),
+        ],
+    )
+    after = manifest_remove(path, "a")
+    assert [e.name for e in after] == ["b"]
+
+
+def test_manifest_remove_missing_is_noop(tmp_path: Path) -> None:
+    path = tmp_path / "mounts"
+    manifest_write(path, [MountEntry("a", Path("/a"))])
+    after = manifest_remove(path, "does-not-exist")
+    assert [e.name for e in after] == ["a"]
+
+
+def test_manifest_prune_removes_nonexistent_hosts(tmp_path: Path) -> None:
+    live = tmp_path / "live"
+    live.mkdir()
+    path = tmp_path / "mounts"
+    manifest_write(
+        path,
+        [
+            MountEntry("live", live),
+            MountEntry("dead", tmp_path / "does-not-exist"),
+        ],
+    )
+    kept, pruned = manifest_prune_stale(path)
+    assert pruned == 1
+    assert [e.name for e in kept] == ["live"]
+    assert manifest_read(path) == kept
+
+
+def test_mount_name_for_path_equals_slug(tmp_path: Path) -> None:
+    p = tmp_path / "remo"
+    p.mkdir()
+    assert mount_name_for_path("remo", p) == "remo"
+
+
+def test_mount_name_for_path_prepends_slug(tmp_path: Path) -> None:
+    p = tmp_path / "feature-x"
+    p.mkdir()
+    assert mount_name_for_path("remo", p) == "remo-feature-x"
+
+
+def test_mount_name_for_path_keeps_prefixed(tmp_path: Path) -> None:
+    p = tmp_path / "remo-fix-e2e"
+    p.mkdir()
+    assert mount_name_for_path("remo", p) == "remo-fix-e2e"
+
+
+def test_mount_name_for_path_slugifies(tmp_path: Path) -> None:
+    p = tmp_path / "Feature_Branch!"
+    p.mkdir()
+    assert mount_name_for_path("remo", p) == "remo-feature-branch"
+
+
+def test_git_root_bridge_entry() -> None:
+    e = git_root_bridge_entry("remo", Path("/r/.git"))
+    assert e.name == "remo-git-root"
+    assert e.host_path == Path("/r/.git")
+
+
+def test_parse_mount_spec_host_only(tmp_path: Path) -> None:
+    (tmp_path / "proj").mkdir()
+    e = parse_mount_spec("remo", str(tmp_path / "proj"))
+    assert e.host_path == tmp_path / "proj"
+    assert e.name == "remo-proj"
+
+
+def test_parse_mount_spec_with_explicit_name(tmp_path: Path) -> None:
+    (tmp_path / "proj").mkdir()
+    e = parse_mount_spec("remo", f"{tmp_path / 'proj'}:custom-name")
+    assert e.name == "custom-name"
+
+
+def test_guest_bridge_script_contains_expected_markers() -> None:
+    script = guest_bridge_script(
+        [MountEntry("remo-feat", Path("/r"))],
+        git_root_name="remo-git-root",
+    )
+    assert "#!/usr/bin/env bash" in script
+    assert "set -euo pipefail" in script
+    assert "My Shared Files/remo-git-root" in script
+    assert "remo-feat" in script

--- a/tools/remo-tart/tests/test_paths.py
+++ b/tools/remo-tart/tests/test_paths.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from remo_tart.paths import (
+    mount_manifest_path,
+    ssh_include_path,
+    ssh_key_path,
+    state_dir,
+    user_ssh_config_path,
+    vm_log_path,
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_state_dir(fake_home: Path) -> None:
+    assert state_dir("remo-dev") == fake_home / ".config" / "remo" / "tart"
+
+
+def test_mount_manifest_path(fake_home: Path) -> None:
+    expected = fake_home / ".config" / "remo" / "tart" / "remo-dev.mounts"
+    assert mount_manifest_path("remo-dev") == expected
+
+
+def test_vm_log_path(fake_home: Path) -> None:
+    assert vm_log_path("remo-dev") == fake_home / ".config" / "remo" / "tart" / "remo-dev.log"
+
+
+def test_ssh_include_path(fake_home: Path) -> None:
+    assert ssh_include_path() == fake_home / ".config" / "remo" / "tart" / "ssh_config"
+
+
+def test_ssh_key_path(fake_home: Path) -> None:
+    expected = fake_home / ".config" / "remo" / "tart" / "ssh" / "remo-dev_ed25519"
+    assert ssh_key_path("remo-dev") == expected
+
+
+def test_user_ssh_config_path(fake_home: Path) -> None:
+    assert user_ssh_config_path() == fake_home / ".ssh" / "config"

--- a/tools/remo-tart/tests/test_provision.py
+++ b/tools/remo-tart/tests/test_provision.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from remo_tart.config import ProjectConfig, ScriptsConfig, VmConfig
+from remo_tart.mount import MountEntry
+from remo_tart.provision import build_guest_script, run_provision
+
+
+def _cfg(packs: list[str] | None = None) -> ProjectConfig:
+    return ProjectConfig(
+        slug="remo",
+        vm=VmConfig(
+            name="remo-dev",
+            base_image="img",
+            cpu=1,
+            memory_gb=1,
+            network="shared",
+        ),
+        packs=packs if packs is not None else ["ios", "rust"],
+        scripts=ScriptsConfig(
+            provision=".tart/provision.sh",
+            verify_worktree=".tart/verify-worktree.sh",
+        ),
+    )
+
+
+def _mounts() -> list[MountEntry]:
+    return [
+        MountEntry("remo-feat", Path("/r")),
+        MountEntry("remo-git-root", Path("/r/.git")),
+    ]
+
+
+def test_script_has_shebang_and_strict_mode() -> None:
+    script = build_guest_script(_cfg(), _mounts(), packs_dir_guest="/P", verify=True)
+    assert script.startswith("#!/usr/bin/env bash")
+    assert "set -euo pipefail" in script
+
+
+def test_script_sources_each_enabled_pack() -> None:
+    script = build_guest_script(
+        _cfg(["ios", "rust", "node"]), _mounts(), packs_dir_guest="/P", verify=True
+    )
+    assert 'source "/P/ios.sh"' in script or "source '/P/ios.sh'" in script
+    assert 'source "/P/rust.sh"' in script or "source '/P/rust.sh'" in script
+    assert 'source "/P/node.sh"' in script or "source '/P/node.sh'" in script
+
+
+def test_script_calls_ensure_function_for_each_pack() -> None:
+    script = build_guest_script(_cfg(["ios", "rust"]), _mounts(), packs_dir_guest="/P", verify=True)
+    assert "tart_pack_ios_ensure" in script
+    assert "tart_pack_rust_ensure" in script
+
+
+def test_script_uses_primary_mount_for_project_scripts() -> None:
+    script = build_guest_script(_cfg(), _mounts(), packs_dir_guest="/P", verify=True)
+    # primary mount is remo-feat (first non-git-root)
+    assert "/Volumes/My Shared Files/remo-feat/.tart/provision.sh" in script
+
+
+def test_script_includes_verify_when_verify_true() -> None:
+    script = build_guest_script(_cfg(), _mounts(), packs_dir_guest="/P", verify=True)
+    assert "/Volumes/My Shared Files/remo-feat/.tart/verify-worktree.sh" in script
+
+
+def test_script_omits_verify_when_verify_false() -> None:
+    script = build_guest_script(_cfg(), _mounts(), packs_dir_guest="/P", verify=False)
+    assert "verify-worktree.sh" not in script
+
+
+def test_script_skips_git_root_bridge_for_primary_mount_selection() -> None:
+    """If mounts only contain git-root bridge, no primary exists — this should fail loudly."""
+    import pytest
+
+    from remo_tart.errors import RemoTartError
+
+    with pytest.raises(RemoTartError):
+        build_guest_script(
+            _cfg(),
+            [MountEntry("remo-git-root", Path("/r/.git"))],
+            packs_dir_guest="/P",
+            verify=True,
+        )
+
+
+def test_script_with_empty_packs_list() -> None:
+    script = build_guest_script(_cfg(packs=[]), _mounts(), packs_dir_guest="/P", verify=False)
+    # No `source` lines for packs, but the project provision script still runs
+    assert "source" not in script
+    assert "provision.sh" in script
+
+
+@patch("remo_tart.provision.vm.exec_interactive")
+def test_run_provision_invokes_vm_exec_interactive(exec_i: MagicMock) -> None:
+    exec_i.return_value = 0
+    result = run_provision("remo-dev", _cfg(), _mounts(), verify=True)
+    assert result == 0
+    exec_i.assert_called_once()
+    (called_vm, called_argv) = exec_i.call_args[0]
+    assert called_vm == "remo-dev"
+    assert called_argv[0:2] == ["bash", "-c"]
+    # The third element is the generated script
+    assert "#!/usr/bin/env bash" in called_argv[2]
+
+
+@patch("remo_tart.provision.vm.exec_interactive")
+def test_run_provision_propagates_nonzero(exec_i: MagicMock) -> None:
+    exec_i.return_value = 7
+    assert run_provision("remo-dev", _cfg(), _mounts(), verify=False) == 7

--- a/tools/remo-tart/tests/test_ssh.py
+++ b/tools/remo-tart/tests/test_ssh.py
@@ -39,8 +39,16 @@ def test_managed_block_contains_required_fields() -> None:
 
 def test_block_marker_pair() -> None:
     begin, end = block_marker_pair("remo-dev")
-    assert begin.startswith("# >>>") and "remo-dev" in begin  # noqa: PT018
-    assert end.startswith("# <<<") and "remo-dev" in end  # noqa: PT018
+    assert begin.startswith("# >>>")
+    assert "remo-dev" in begin
+    assert end.startswith("# <<<")
+    assert "remo-dev" in end
+
+
+def test_markers_match_bash_format() -> None:
+    begin, end = block_marker_pair("remo-dev")
+    assert begin == "# >>> remo tart managed: remo-dev >>>"
+    assert end == "# <<< remo tart managed: remo-dev <<<"
 
 
 def test_upsert_managed_block_inserts_into_empty_file(tmp_path: Path) -> None:
@@ -59,9 +67,17 @@ def test_upsert_managed_block_replaces_existing(tmp_path: Path) -> None:
     text = path.read_text()
     assert "block-v1" not in text
     assert "block-v2" in text
-    # exactly one marker pair for this VM
-    assert text.count(">>>") == 1
-    assert text.count("<<<") == 1
+    # Exactly one marker pair remains — begin has 2 ">>>" tokens, end has 2 "<<<".
+    assert text.count(">>>") == 2
+    assert text.count("<<<") == 2
+
+
+def test_upsert_managed_block_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "tart_config"
+    upsert_managed_block(path, "remo-dev", "body\n")
+    first = path.read_text()
+    upsert_managed_block(path, "remo-dev", "body\n")
+    assert path.read_text() == first
 
 
 def test_remove_managed_block_is_noop_when_absent(tmp_path: Path) -> None:

--- a/tools/remo-tart/tests/test_ssh.py
+++ b/tools/remo-tart/tests/test_ssh.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import shutil
+import stat
+from pathlib import Path
+
+import pytest
+
+from remo_tart.ssh import (
+    block_marker_pair,
+    ensure_include_in_user_config,
+    generate_keypair,
+    managed_block,
+    public_key,
+    remote_authority,
+    remove_include_from_user_config,
+    remove_managed_block,
+    ssh_alias,
+    upsert_managed_block,
+)
+
+
+def test_ssh_alias() -> None:
+    assert ssh_alias("remo-dev") == "tart-remo-dev"
+
+
+def test_remote_authority() -> None:
+    assert remote_authority("remo-dev", "admin", "10.0.0.2") == "ssh-remote+admin@10.0.0.2"
+
+
+def test_managed_block_contains_required_fields() -> None:
+    block = managed_block("remo-dev", "admin", Path("/k/remo-dev_ed25519"))
+    assert "Host tart-remo-dev" in block
+    assert "User admin" in block
+    assert "IdentityFile /k/remo-dev_ed25519" in block
+    assert "StrictHostKeyChecking no" in block
+    assert "ProxyCommand tart exec -i remo-dev" in block
+
+
+def test_block_marker_pair() -> None:
+    begin, end = block_marker_pair("remo-dev")
+    assert begin.startswith("# >>>") and "remo-dev" in begin  # noqa: PT018
+    assert end.startswith("# <<<") and "remo-dev" in end  # noqa: PT018
+
+
+def test_upsert_managed_block_inserts_into_empty_file(tmp_path: Path) -> None:
+    path = tmp_path / "tart_config"
+    upsert_managed_block(path, "remo-dev", "Host tart-remo-dev\n  HostName x\n")
+    text = path.read_text()
+    assert "# >>>" in text
+    assert "Host tart-remo-dev" in text
+    assert "# <<<" in text
+
+
+def test_upsert_managed_block_replaces_existing(tmp_path: Path) -> None:
+    path = tmp_path / "tart_config"
+    upsert_managed_block(path, "remo-dev", "block-v1\n")
+    upsert_managed_block(path, "remo-dev", "block-v2\n")
+    text = path.read_text()
+    assert "block-v1" not in text
+    assert "block-v2" in text
+    # exactly one marker pair for this VM
+    assert text.count(">>>") == 1
+    assert text.count("<<<") == 1
+
+
+def test_remove_managed_block_is_noop_when_absent(tmp_path: Path) -> None:
+    path = tmp_path / "tart_config"
+    remove_managed_block(path, "remo-dev")
+    assert not path.exists() or path.read_text() == ""
+
+
+def test_remove_managed_block_removes_only_that_vm(tmp_path: Path) -> None:
+    path = tmp_path / "tart_config"
+    upsert_managed_block(path, "remo-dev", "keep-me-dev\n")
+    upsert_managed_block(path, "other-vm", "remove-me\n")
+    remove_managed_block(path, "other-vm")
+    text = path.read_text()
+    assert "keep-me-dev" in text
+    assert "remove-me" not in text
+
+
+def test_ensure_include_adds_include_directive(tmp_path: Path) -> None:
+    user = tmp_path / "config"
+    include = tmp_path / "tart_config"
+    ensure_include_in_user_config(user, include)
+    text = user.read_text()
+    assert f"Include {include}" in text
+    # idempotent
+    ensure_include_in_user_config(user, include)
+    assert user.read_text().count(f"Include {include}") == 1
+
+
+def test_remove_include_cleans_up(tmp_path: Path) -> None:
+    user = tmp_path / "config"
+    include = tmp_path / "tart_config"
+    ensure_include_in_user_config(user, include)
+    remove_include_from_user_config(user, include)
+    assert f"Include {include}" not in user.read_text()
+
+
+@pytest.mark.skipif(shutil.which("ssh-keygen") is None, reason="ssh-keygen not available")
+def test_generate_keypair(tmp_path: Path) -> None:
+    key = tmp_path / "k_ed25519"
+    generate_keypair(key)
+    assert key.is_file()
+    assert key.with_suffix(key.suffix + ".pub").is_file()
+    # ssh-keygen writes 600 on the private key
+    mode = stat.S_IMODE(key.stat().st_mode)
+    assert mode & 0o077 == 0
+    pub = public_key(key)
+    assert pub.startswith("ssh-ed25519 ")
+
+
+@pytest.mark.skipif(shutil.which("ssh-keygen") is None, reason="ssh-keygen not available")
+def test_generate_keypair_idempotent(tmp_path: Path) -> None:
+    key = tmp_path / "k_ed25519"
+    generate_keypair(key)
+    first_content = key.read_bytes()
+    generate_keypair(key)  # second call must not regenerate
+    assert key.read_bytes() == first_content

--- a/tools/remo-tart/tests/test_state.py
+++ b/tools/remo-tart/tests/test_state.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from remo_tart.state import Action, VmState, decide
+
+
+def test_missing_vm_returns_create() -> None:
+    assert decide(VmState(exists=False, running=False, mount_matches=False)) == [Action.CREATE]
+    # "running" and "mount_matches" are irrelevant when exists=False
+    assert decide(VmState(exists=False, running=True, mount_matches=True)) == [Action.CREATE]
+
+
+def test_stopped_without_mount() -> None:
+    assert decide(VmState(exists=True, running=False, mount_matches=False)) == [
+        Action.ATTACH_MOUNT_AND_START
+    ]
+
+
+def test_stopped_with_mount() -> None:
+    assert decide(VmState(exists=True, running=False, mount_matches=True)) == [Action.START]
+
+
+def test_running_without_mount() -> None:
+    assert decide(VmState(exists=True, running=True, mount_matches=False)) == [
+        Action.UPDATE_MOUNT_AND_RESTART
+    ]
+
+
+def test_running_with_mount_is_nothing() -> None:
+    assert decide(VmState(exists=True, running=True, mount_matches=True)) == [Action.NOTHING]

--- a/tools/remo-tart/tests/test_status.py
+++ b/tools/remo-tart/tests/test_status.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from remo_tart.mount import MountEntry, manifest_write
+from remo_tart.paths import mount_manifest_path, ssh_include_path, ssh_key_path
+from remo_tart.status import collect, render_human, render_json
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+@patch("remo_tart.status.vm.exists")
+@patch("remo_tart.status.vm.is_running")
+@patch("remo_tart.status.vm.ip_address")
+@patch("remo_tart.status.launchd.job_present")
+def test_collect_running_vm(
+    job_present: MagicMock,
+    ip: MagicMock,
+    is_running: MagicMock,
+    exists: MagicMock,
+    fake_home: Path,
+    tmp_path: Path,
+) -> None:
+    exists.return_value = True
+    is_running.return_value = True
+    ip.return_value = "10.0.0.2"
+    job_present.return_value = True
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    # Pre-populate manifest
+    manifest_write(
+        mount_manifest_path("remo-dev"),
+        [
+            MountEntry("remo-feat", repo),
+            MountEntry("remo-git-root", repo / ".git"),
+        ],
+    )
+
+    data = collect("remo-dev", repo, repo)
+    assert data["vm"]["name"] == "remo-dev"
+    assert data["vm"]["exists"] is True
+    assert data["vm"]["running"] is True
+    assert data["vm"]["ip"] == "10.0.0.2"
+    assert data["launchd"]["label"].startswith("com.remo.tart.")
+    assert data["launchd"]["job_present"] is True
+    assert data["mounts"]["count"] == 2
+    assert data["mounts"]["selected"] == "remo-feat"
+    assert data["mounts"]["git_root_present"] is True
+    assert {"name": "remo-feat", "host_path": str(repo)} in data["mounts"]["entries"]
+
+
+@patch("remo_tart.status.vm.exists", return_value=False)
+@patch("remo_tart.status.vm.is_running", return_value=False)
+@patch("remo_tart.status.vm.ip_address", return_value=None)
+@patch("remo_tart.status.launchd.job_present", return_value=False)
+def test_collect_missing_vm(
+    job_present: MagicMock,
+    ip: MagicMock,
+    is_running: MagicMock,
+    exists: MagicMock,
+    fake_home: Path,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    data = collect("remo-dev", repo, repo)
+    assert data["vm"]["exists"] is False
+    assert data["vm"]["ip"] is None
+    assert data["mounts"]["count"] == 0
+    assert data["mounts"]["selected"] is None
+    assert data["mounts"]["git_root_present"] is False
+
+
+@patch("remo_tart.status.vm.exists", return_value=True)
+@patch("remo_tart.status.vm.is_running", return_value=True)
+@patch("remo_tart.status.vm.ip_address", return_value=None)
+@patch("remo_tart.status.launchd.job_present", return_value=False)
+def test_collect_includes_ssh_section(
+    mock_job_present: MagicMock,
+    mock_ip: MagicMock,
+    mock_is_running: MagicMock,
+    mock_exists: MagicMock,
+    fake_home: Path,
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    data = collect("remo-dev", repo, repo)
+    assert "ssh" in data
+    assert data["ssh"]["include_path"] == str(ssh_include_path())
+    assert data["ssh"]["key_path"] == str(ssh_key_path("remo-dev"))
+    assert data["ssh"]["key_present"] is False
+    assert data["ssh"]["include_present_in_user_config"] is False
+
+
+def test_render_human_includes_section_headers() -> None:
+    data = {
+        "vm": {"name": "remo-dev", "exists": True, "running": True, "ip": "10.0.0.2"},
+        "launchd": {"label": "com.remo.tart.remo-dev", "job_present": True},
+        "mounts": {
+            "manifest_path": "/m.mounts",
+            "count": 1,
+            "selected": "remo-feat",
+            "git_root_present": True,
+            "entries": [{"name": "remo-feat", "host_path": "/r"}],
+        },
+        "ssh": {
+            "include_path": "/i",
+            "key_path": "/k",
+            "key_present": True,
+            "include_present_in_user_config": False,
+        },
+    }
+    text = render_human(data)
+    assert "vm:" in text
+    assert "launchd:" in text
+    assert "mounts:" in text
+    assert "ssh:" in text
+    # Booleans rendered as lowercase
+    assert "running=true" in text
+    assert "include_present_in_user_config=false" in text
+    # Entries listed
+    assert "remo-feat=/r" in text
+
+
+def test_render_human_handles_none_and_empty_entries() -> None:
+    data = {
+        "vm": {"name": "x", "exists": False, "running": False, "ip": None},
+        "launchd": {"label": "com.remo.tart.x", "job_present": False},
+        "mounts": {
+            "manifest_path": "/m",
+            "count": 0,
+            "selected": None,
+            "git_root_present": False,
+            "entries": [],
+        },
+        "ssh": {
+            "include_path": "/i",
+            "key_path": "/k",
+            "key_present": False,
+            "include_present_in_user_config": False,
+        },
+    }
+    text = render_human(data)
+    assert "ip=null" in text
+    assert "selected=null" in text
+
+
+def test_render_json_is_valid_json() -> None:
+    data = {
+        "vm": {"name": "x", "exists": True, "running": True, "ip": "1.2.3.4"},
+        "launchd": {"label": "com.remo.tart.x", "job_present": True},
+        "mounts": {
+            "manifest_path": "/m",
+            "count": 0,
+            "selected": None,
+            "git_root_present": False,
+            "entries": [],
+        },
+        "ssh": {
+            "include_path": "/i",
+            "key_path": "/k",
+            "key_present": False,
+            "include_present_in_user_config": False,
+        },
+    }
+    out = render_json(data)
+    parsed = json.loads(out)
+    assert parsed == data

--- a/tools/remo-tart/tests/test_vm.py
+++ b/tools/remo-tart/tests/test_vm.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from remo_tart import vm
+from remo_tart.mount import MountEntry
+
+
+@patch("subprocess.run")
+def test_list_names_parses_stdout(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="remo-dev\nother\n", stderr="")
+    assert vm.list_names() == ["remo-dev", "other"]
+
+
+@patch("subprocess.run")
+def test_list_names_strips_blank_lines(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="\nremo-dev\n\nother\n\n", stderr="")
+    assert vm.list_names() == ["remo-dev", "other"]
+
+
+@patch("subprocess.run")
+def test_exists_true_when_in_list(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="remo-dev\n", stderr="")
+    assert vm.exists("remo-dev") is True
+
+
+@patch("subprocess.run")
+def test_exists_false_when_not_in_list(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="remo-dev\n", stderr="")
+    assert vm.exists("other") is False
+
+
+@patch("subprocess.run")
+def test_get_state_parses_json(run: MagicMock) -> None:
+    run.return_value = MagicMock(
+        returncode=0,
+        stdout=json.dumps({"State": "running", "CPU": 6}),
+        stderr="",
+    )
+    assert vm.get_state("remo-dev")["State"] == "running"
+
+
+@patch("subprocess.run")
+def test_is_running_true(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout=json.dumps({"State": "running"}), stderr="")
+    assert vm.is_running("remo-dev") is True
+
+
+@patch("subprocess.run")
+def test_is_running_false(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout=json.dumps({"State": "stopped"}), stderr="")
+    assert vm.is_running("remo-dev") is False
+
+
+@patch("subprocess.run")
+def test_is_running_case_insensitive(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout=json.dumps({"state": "Running"}), stderr="")
+    assert vm.is_running("remo-dev") is True
+
+
+def test_build_run_args_bridged_network_and_mounts() -> None:
+    mounts = [
+        MountEntry("remo", Path("/r")),
+        MountEntry("remo-git-root", Path("/r/.git")),
+    ]
+    args = vm.build_run_args("remo-dev", network="bridged:en0", mounts=mounts)
+    # positional: ["run", "remo-dev"]
+    assert args[0:2] == ["run", "remo-dev"]
+    # network flag present
+    assert "--net-bridged" in args
+    idx = args.index("--net-bridged")
+    assert args[idx + 1] == "en0"
+    # each mount adds --dir <name>:<host-path>:rw
+    assert any("remo:/r" in a for a in args)
+    assert any("remo-git-root:/r/.git" in a for a in args)
+
+
+def test_build_run_args_shared_network() -> None:
+    args = vm.build_run_args("remo-dev", network="shared", mounts=[])
+    assert "--net-shared" in args
+
+
+def test_build_run_args_softnet() -> None:
+    args = vm.build_run_args("remo-dev", network="softnet", mounts=[])
+    assert "--net-softnet" in args
+
+
+@patch("subprocess.run")
+def test_create_invokes_tart_clone(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    vm.create("remo-dev", "ghcr.io/org/img:tag")
+    (called_argv,) = run.call_args[0]
+    assert called_argv[0:3] == ["tart", "clone", "ghcr.io/org/img:tag"]
+    assert called_argv[3] == "remo-dev"
+
+
+@patch("subprocess.run")
+def test_delete_invokes_tart_delete(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    vm.delete("remo-dev")
+    (called_argv,) = run.call_args[0]
+    assert called_argv == ["tart", "delete", "remo-dev"]
+
+
+@patch("subprocess.run")
+def test_set_resources(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    vm.set_resources("remo-dev", cpu=6, memory_gb=12)
+    (called_argv,) = run.call_args[0]
+    assert called_argv[0:3] == ["tart", "set", "remo-dev"]
+    # --cpu 6 --memory 12288 (MB) or similar — check both appear
+    assert "--cpu" in called_argv
+    assert str(6) in called_argv
+    assert "--memory" in called_argv
+
+
+@patch("subprocess.run")
+def test_exec_capture_returns_completed_process(run: MagicMock) -> None:
+    cp = MagicMock(returncode=0, stdout="hello", stderr="")
+    run.return_value = cp
+    result = vm.exec_capture("remo-dev", ["echo", "hello"])
+    assert result is cp
+    (called_argv,) = run.call_args[0]
+    assert called_argv[0:3] == ["tart", "exec", "remo-dev"]
+    assert called_argv[-2:] == ["echo", "hello"]
+
+
+@patch("subprocess.run")
+def test_ip_address_returns_stdout(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0, stdout="10.0.0.2\n", stderr="")
+    assert vm.ip_address("remo-dev") == "10.0.0.2"
+
+
+@patch("subprocess.run")
+def test_ip_address_returns_none_when_tart_ip_fails(run: MagicMock) -> None:
+    # tart ip fails (returncode != 0); fallback also fails
+    run.return_value = MagicMock(returncode=1, stdout="", stderr="not running")
+    assert vm.ip_address("remo-dev") is None

--- a/tools/remo-tart/tests/test_worktree.py
+++ b/tools/remo-tart/tests/test_worktree.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from remo_tart.config import ProjectConfig, ScriptsConfig, VmConfig
+from remo_tart.state import Action, VmState
+from remo_tart.worktree import AttachOutcome, ensure_attached
+
+
+def _cfg() -> ProjectConfig:
+    return ProjectConfig(
+        slug="remo",
+        vm=VmConfig(
+            name="remo-dev",
+            base_image="img",
+            cpu=1,
+            memory_gb=1,
+            network="shared",
+        ),
+        packs=["ios"],
+        scripts=ScriptsConfig(
+            provision=".tart/provision.sh",
+            verify_worktree=".tart/verify-worktree.sh",
+        ),
+    )
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_create")
+def test_missing_vm_triggers_create(
+    create: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    read.return_value = VmState(exists=False, running=False, mount_matches=False)
+    outcome = ensure_attached(fake_repo, _cfg(), fake_repo)
+    create.assert_called_once()
+    config_ssh.assert_called_once()
+    assert isinstance(outcome, AttachOutcome)
+    assert Action.CREATE in outcome.actions
+
+
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_nothing")
+def test_healthy_state_is_nothing_and_skips_ssh_reconfig(
+    nothing: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    read.return_value = VmState(exists=True, running=True, mount_matches=True)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+    nothing.assert_called_once()
+    # NOTHING path does NOT re-configure SSH (no duplicate key injection)
+    config_ssh.assert_not_called()
+
+
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_update_mount_and_restart")
+def test_running_with_mismatched_mount_triggers_update_and_restart(
+    update: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    read.return_value = VmState(exists=True, running=True, mount_matches=False)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+    update.assert_called_once()
+    config_ssh.assert_called_once()
+
+
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_start")
+def test_stopped_with_matching_mount_triggers_start(
+    start: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    read.return_value = VmState(exists=True, running=False, mount_matches=True)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+    start.assert_called_once()
+    config_ssh.assert_called_once()
+
+
+def test_ensure_attached_upserts_primary_and_git_root(fake_home: Path, fake_repo: Path) -> None:
+    """The manifest must contain both the worktree entry and the git-root bridge."""
+    from remo_tart.paths import mount_manifest_path
+
+    with (
+        patch("remo_tart.worktree._read_state") as read,
+        patch("remo_tart.worktree._action_nothing"),
+        patch("remo_tart.worktree._configure_ssh"),
+    ):
+        read.return_value = VmState(exists=True, running=True, mount_matches=True)
+        ensure_attached(fake_repo, _cfg(), fake_repo)
+
+    entries = list(_read_manifest(mount_manifest_path("remo-dev")))
+    names = {e.name for e in entries}
+    assert "remo-git-root" in names
+    # primary mount name is derived from worktree basename
+    assert any(n.startswith("remo") and n != "remo-git-root" for n in names)
+
+
+def _read_manifest(path: Path) -> list:
+    from remo_tart.mount import manifest_read
+
+    return manifest_read(path)

--- a/tools/remo-tart/tests/test_worktree.py
+++ b/tools/remo-tart/tests/test_worktree.py
@@ -130,3 +130,190 @@ def _read_manifest(path: Path) -> list:
     from remo_tart.mount import manifest_read
 
     return manifest_read(path)
+
+
+# ---------------------------------------------------------------------------
+# C1: Stale launchd cleanup + log truncation before submit
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.worktree.launchd.submit")
+@patch("remo_tart.worktree.launchd.remove")
+@patch("remo_tart.worktree._wait_for_guest_exec")
+def test_action_create_cleans_stale_launchd_and_truncates_log(
+    wait: MagicMock,
+    remove: MagicMock,
+    submit: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.paths import vm_log_path
+    from remo_tart.worktree import _action_create
+
+    log = vm_log_path("remo-dev")
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("stale content\n")
+
+    with patch("remo_tart.worktree.vm.create"), patch("remo_tart.worktree.vm.set_resources"):
+        _action_create(_cfg(), [], log, Path("/tmp/k"))
+
+    # stale log truncated
+    assert log.read_text() == ""
+    # launchctl remove called before submit
+    remove.assert_called_once()
+    submit.assert_called_once()
+
+
+@patch("remo_tart.worktree.launchd.submit")
+@patch("remo_tart.worktree.launchd.remove")
+@patch("remo_tart.worktree._wait_for_guest_exec")
+def test_action_start_cleans_stale_launchd_and_truncates_log(
+    wait: MagicMock,
+    remove: MagicMock,
+    submit: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.paths import vm_log_path
+    from remo_tart.worktree import _action_start
+
+    log = vm_log_path("remo-dev")
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("stale content\n")
+
+    _action_start(_cfg(), [], log)
+
+    # stale log truncated
+    assert log.read_text() == ""
+    # launchctl remove called before submit
+    remove.assert_called_once()
+    submit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# C2: Duplicate authorized_keys injection — idempotent inject command
+# ---------------------------------------------------------------------------
+
+
+def test_inject_command_is_idempotent_shape(tmp_path: Path) -> None:
+    from remo_tart.worktree import _build_inject_command
+
+    cmd = _build_inject_command("ssh-ed25519 AAAAC... remo-tart")
+    assert "grep -Fqx" in cmd
+    assert "||" in cmd
+    # Shell-safe quoting
+    assert "'ssh-ed25519 AAAAC... remo-tart'" in cmd
+
+
+# ---------------------------------------------------------------------------
+# C3: Honor exec_capture returncode when injecting the key
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.worktree.vm.exec_capture")
+@patch("remo_tart.worktree.ssh.ensure_include_in_user_config")
+@patch("remo_tart.worktree.ssh.upsert_managed_block")
+@patch("remo_tart.worktree.ssh.generate_keypair")
+@patch("remo_tart.worktree.ssh.public_key", return_value="ssh-ed25519 AAA test")
+def test_configure_ssh_raises_when_guest_injection_fails(
+    pubkey: MagicMock,
+    genkey: MagicMock,
+    upsert: MagicMock,
+    ensure_include: MagicMock,
+    exec_capture: MagicMock,
+    fake_home: Path,
+) -> None:
+    from remo_tart.errors import RemoTartError
+    from remo_tart.worktree import _configure_ssh
+
+    exec_capture.return_value = MagicMock(returncode=1, stderr="boom", stdout="")
+    with pytest.raises(RemoTartError) as excinfo:
+        _configure_ssh(_cfg(), Path("/tmp/k"))
+    assert excinfo.value.hint is not None
+
+
+# ---------------------------------------------------------------------------
+# C4: _wait_for_guest_exec polls exec, not just is_running
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.worktree.vm.exec_capture")
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+def test_wait_for_guest_exec_polls_exec_capture(
+    is_running: MagicMock,
+    exec_capture: MagicMock,
+) -> None:
+    from remo_tart.worktree import _wait_for_guest_exec
+
+    exec_capture.return_value = MagicMock(returncode=0)
+    _wait_for_guest_exec("remo-dev", attempts=3, interval=0.0)
+
+    exec_capture.assert_called_with("remo-dev", ["/usr/bin/true"])
+
+
+@patch("remo_tart.worktree.vm.exec_capture")
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+def test_wait_for_guest_exec_raises_on_timeout(
+    is_running: MagicMock,
+    exec_capture: MagicMock,
+) -> None:
+    from remo_tart.errors import RemoTartError
+    from remo_tart.worktree import _wait_for_guest_exec
+
+    exec_capture.return_value = MagicMock(returncode=1)
+    with pytest.raises(RemoTartError):
+        _wait_for_guest_exec("remo-dev", attempts=2, interval=0.0)
+
+
+# ---------------------------------------------------------------------------
+# I1: launchctl remove ordering in update-and-restart
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.worktree.launchd.job_present", return_value=False)
+@patch("remo_tart.worktree.launchd.submit")
+@patch("remo_tart.worktree.launchd.remove")
+@patch("remo_tart.worktree._wait_for_stopped")
+@patch("remo_tart.worktree._wait_for_guest_exec")
+def test_update_and_restart_removes_before_submit(
+    wait_exec: MagicMock,
+    wait_stopped: MagicMock,
+    remove: MagicMock,
+    submit: MagicMock,
+    job_present: MagicMock,
+    fake_home: Path,
+) -> None:
+    from remo_tart.worktree import _action_update_mount_and_restart
+
+    _action_update_mount_and_restart(_cfg(), [], Path("/tmp/log"))
+
+    # remove was called before submit
+    assert remove.call_count == 1
+    assert submit.call_count == 1
+    # Assertion on ordering via mock_calls
+    remove_ts = remove.call_args_list
+    submit_ts = submit.call_args_list
+    assert len(remove_ts) == 1
+    assert len(submit_ts) == 1
+
+
+# ---------------------------------------------------------------------------
+# I3: AttachOutcome shape — tuples and primary field
+# ---------------------------------------------------------------------------
+
+
+def test_attach_outcome_has_primary_and_immutable_fields(fake_home: Path, fake_repo: Path) -> None:
+    with (
+        patch("remo_tart.worktree._read_state") as read,
+        patch("remo_tart.worktree._action_nothing"),
+        patch("remo_tart.worktree._configure_ssh"),
+    ):
+        read.return_value = VmState(exists=True, running=True, mount_matches=True)
+        outcome = ensure_attached(fake_repo, _cfg(), fake_repo)
+
+    assert isinstance(outcome.actions, tuple)
+    assert isinstance(outcome.manifest, tuple)
+    assert outcome.primary.host_path == fake_repo.resolve()
+    # Frozen dataclass forbids rebinding
+    with pytest.raises((AttributeError, TypeError)):
+        outcome.primary = outcome.primary  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Migrate Tart VM lifecycle logic from `scripts/tart/*.sh` (~2000 LOC bash) to native Python modules under `tools/remo-tart/src/remo_tart/`.
- New modules: `paths`, `config`, `mount`, `ssh`, `launchd`, `state`, `vm`, `worktree`, `provision`, `connect`, `status`, `doctor`.
- Migrate config `.tart/project.sh` → `.tart/project.toml` + `.tart/provision.sh` + `.tart/verify-worktree.sh`. `project.sh` left in place for PR 3 cleanup.
- Rewire every `remo-tart` subcommand to native modules (no more `bash_dispatch`).
- Pydantic-validated config; legacy `project.sh` detected with hint.
- Pure modules fully unit-tested; subprocess wrappers tested via mocks.

Implements PR 2 of the plan tracked locally at `docs/superpowers/plans/2026-04-24-remo-tart-cli-pr2-python-core.md` (not committed). PR 3 deletes the now-dead bash scripts.

## Test plan
- [x] `uv run pytest -v` — 154 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv tool install --reinstall --editable tools/remo-tart` works; `remo-tart --help` shows all 10 subcommands
- [x] `remo-tart status` outside the repo: structured `error:` + `hint:`, exit 1
- [x] `remo-tart status` inside the repo: native Python status output (sections vm/launchd/mounts/ssh)
- [ ] **Manual real-VM matrix (must run on host with Tart before merge)**:
  - VM absent → `remo-tart up`: create + provision + boot + cli shell
  - VM running → `remo-tart up`: instant connect, no reboot
  - Different worktree → `remo-tart up`: re-attach + restart + connect
  - `destroy --force` then `up vscode`: VS Code Remote SSH opens
  - Stop VM via `launchctl remove`; `up`: clean reboot
  - `status --json` in each state: valid JSON
  - `doctor` healthy: 0 issues; deleted manifest path: ≥1 issue with hint

## Notes
- Launchd uses `launchctl submit` (in-memory), no plist file — matches existing bash behavior.
- `.tart/packs/*.sh` remain bash; provisioning shells into them on the guest.
- `_GUEST_USER = "admin"` hardcoded with `# TODO(pr3): move to config` — thread through `ProjectConfig` in PR 3.
- Module-name collisions (`connect`, `status`, `doctor`, `ssh`) resolved via underscore-prefixed import aliases in `cli.py` (e.g. `from remo_tart import connect as _connect`).

## Notable in-flight fixes
- `d573a7f` mount prune/remove short-circuit on missing manifest + stricter `is_dir()` check + parameterised guest password.
- `e56e1a0` ssh markers preserve bash format (trailing arrow clusters) for backward compat.
- `9f9aae9` worktree orchestrator: launchd stale cleanup, idempotent SSH key injection, guest-exec readiness loop instead of just `is_running`.
- `52f67ba` cli `ssh` defaults to `zsh -l` when no args; `connect` raises actionable error on empty manifest.