### PR TITLE
fix(remo-tart): make first VM boot actually work + progress UX + --display

### DIFF
--- a/tools/remo-tart/src/remo_tart/cli.py
+++ b/tools/remo-tart/src/remo_tart/cli.py
@@ -102,13 +102,29 @@ def main(ctx: click.Context, verbose: int) -> None:
 
 @main.command()
 @click.argument("mode", type=click.Choice(["cli", "vscode", "cursor"]), default="cli")
+@click.option(
+    "--display",
+    is_flag=True,
+    help="Boot with a UI window. Triggers a restart if VM is currently headless.",
+)
 @click.pass_context
-def up(ctx: click.Context, mode: str) -> None:
-    """Attach the current worktree, ensure the VM is running, and connect."""
+def up(ctx: click.Context, mode: str, display: bool) -> None:
+    """Attach the current worktree, ensure the VM is running, and connect.
+
+    By default the VM runs headless (no UI window). Use ``--display`` if you
+    need to see the VM screen (rarely needed; macOS guest is normally driven
+    via SSH / Remote SSH editors).
+    """
+    from remo_tart.console import done as _done
+    from remo_tart.console import step as _step
+
     repo, project = _load_cfg(ctx)
     cwd = Path.cwd()
-    outcome = worktree.ensure_attached(repo, project, cwd)
+    _step(f"up({mode}) for worktree {cwd}")
+    outcome = worktree.ensure_attached(repo, project, cwd, headless=not display)
+    _done(f"actions: {', '.join(a.name for a in outcome.actions)}")
     name = project.vm.name
+    _step(f"connecting via {mode}")
     if mode == "cli":
         code = _connect.connect_cli(name, project.vm.guest_user)
     elif mode == "vscode":
@@ -136,8 +152,13 @@ def use(ctx: click.Context, worktree_path: str | None) -> None:
 
 
 @main.command()
+@click.option(
+    "--display",
+    is_flag=True,
+    help="Boot with a UI window. Default is headless.",
+)
 @click.pass_context
-def start(ctx: click.Context) -> None:
+def start(ctx: click.Context, display: bool) -> None:
     """Start the VM without changing mounts or connecting."""
     _repo, project = _load_cfg(ctx)
     name = project.vm.name
@@ -154,7 +175,7 @@ def start(ctx: click.Context) -> None:
     # Truncate log to avoid confusion with stale output
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("")
-    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=not display)
     launchd.submit(label, tart_args, log_path)
 
 

--- a/tools/remo-tart/src/remo_tart/console.py
+++ b/tools/remo-tart/src/remo_tart/console.py
@@ -20,3 +20,13 @@ def render_error(console: Console, err: RemoTartError) -> None:
     console.print(f"[red]error:[/red] {err}")
     if err.hint:
         console.print(f"[dim]hint:[/dim] {err.hint}")
+
+
+def step(msg: str) -> None:
+    """Print a progress step. Use for long-running orchestrator phases."""
+    get_console().print(f"[cyan]→[/cyan] {msg}")
+
+
+def done(msg: str) -> None:
+    """Print a completion step."""
+    get_console().print(f"[green]✓[/green] {msg}")

--- a/tools/remo-tart/src/remo_tart/vm.py
+++ b/tools/remo-tart/src/remo_tart/vm.py
@@ -178,11 +178,21 @@ def exec_interactive(name: str, argv: list[str]) -> int:
 # ---------------------------------------------------------------------------
 
 
-def build_run_args(name: str, network: str, mounts: list[MountEntry]) -> list[str]:
+def build_run_args(
+    name: str,
+    network: str,
+    mounts: list[MountEntry],
+    *,
+    headless: bool = True,
+) -> list[str]:
     """Return the ``tart run`` argv list for *name* (without the ``tart`` prefix).
 
     This is a **pure function** — it never shells out.  The launchd submitter
     calls it to compose the run command before handing it to ``launchctl``.
+
+    By default the VM runs **headless** (``--no-graphics``); set
+    ``headless=False`` to open a UI window (useful for debugging boot, GUI
+    work, or running an installer that needs the display).
 
     Network strings:
     - ``"shared"``        → ``["--net-shared"]``
@@ -190,9 +200,13 @@ def build_run_args(name: str, network: str, mounts: list[MountEntry]) -> list[st
     - ``"bridged:<iface>"`` → ``["--net-bridged", "<iface>"]``
 
     Each :class:`~remo_tart.mount.MountEntry` adds
-    ``["--dir", "<name>:<host_path>:rw"]``.
+    ``["--dir", "<name>:<host_path>"]``.  Tart's ``--dir`` options are
+    ``ro`` or ``tag=<TAG>`` only — there is no ``rw`` option (rw is the default).
     """
     args: list[str] = ["run", name]
+
+    if headless:
+        args.append("--no-graphics")
 
     # Network
     if network == "shared":
@@ -205,6 +219,6 @@ def build_run_args(name: str, network: str, mounts: list[MountEntry]) -> list[st
 
     # Mounts
     for entry in mounts:
-        args += ["--dir", f"{entry.name}:{entry.host_path}:rw"]
+        args += ["--dir", f"{entry.name}:{entry.host_path}"]
 
     return args

--- a/tools/remo-tart/src/remo_tart/vm.py
+++ b/tools/remo-tart/src/remo_tart/vm.py
@@ -88,7 +88,7 @@ def ip_address(name: str) -> str | None:
 
     # Fallback: ask the guest directly
     fallback = subprocess.run(
-        ["tart", "exec", name, "--", "/usr/bin/ipconfig", "getifaddr", "en0"],
+        ["tart", "exec", name, "/usr/bin/ipconfig", "getifaddr", "en0"],
         capture_output=True,
         text=True,
         check=False,
@@ -152,9 +152,13 @@ def exec_capture(name: str, argv: list[str]) -> subprocess.CompletedProcess:  # 
 
     Returns the :class:`subprocess.CompletedProcess` without raising on
     non-zero exit codes — callers are responsible for checking ``returncode``.
+
+    Note: ``tart exec`` syntax is ``tart exec <vm> <cmd> [args...]`` —
+    there is NO ``--`` separator (tart treats ``--`` as a command name and
+    fails with ``executable file not found``).
     """
     return subprocess.run(
-        ["tart", "exec", name, "--", *argv],
+        ["tart", "exec", name, *argv],
         capture_output=True,
         text=True,
         check=False,
@@ -164,10 +168,11 @@ def exec_capture(name: str, argv: list[str]) -> subprocess.CompletedProcess:  # 
 def exec_interactive(name: str, argv: list[str]) -> int:
     """Run *argv* inside *name* with an inherited tty.
 
-    Returns the exit code of the remote command.
+    Returns the exit code of the remote command.  See :func:`exec_capture`
+    for the note about ``--``.
     """
     result = subprocess.run(
-        ["tart", "exec", name, "--", *argv],
+        ["tart", "exec", name, *argv],
         check=False,
     )
     return result.returncode

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -70,15 +70,8 @@ def ensure_attached(
     log_path = vm_log_path(vm_name)
     key_path = ssh_key_path(vm_name)
 
-    # Step 1: Snapshot pre-upsert state, prune stale entries, then upsert the
-    # primary + git-root bridge entries.
-    pre_upsert = manifest_read(manifest_path)
-    worktree_already_present = any(
-        e.host_path.resolve() == worktree_host_path.resolve() for e in pre_upsert
-    )
-
+    # Step 1: Prune stale entries, then upsert the primary + git-root bridge.
     manifest_prune_stale(manifest_path)
-    target = _target_manifest(project, repo_root, worktree_host_path)
 
     primary_entry = MountEntry(
         name=mount_name_for_path(project.slug, worktree_host_path),
@@ -88,16 +81,19 @@ def ensure_attached(
     manifest_upsert(manifest_path, primary_entry)
     manifest_upsert(manifest_path, bridge_entry)
 
-    # Step 2: Read VM state.  Pass worktree_already_present so _read_state can
-    # use the pre-upsert view when deciding mount_matches (the running VM loaded
-    # the OLD manifest at boot — a restart is needed if the mount wasn't there).
-    vm_state = _read_state(project, manifest_path, worktree_host_path, worktree_already_present)
+    # Step 2: Read VM state.  ``mount_matches`` is computed against the
+    # *running* VM's actual mounts (queried via tart exec), not the on-disk
+    # manifest — the manifest can drift ahead of the running VM if mounts
+    # were upserted between boots.
+    vm_state = _read_state(project, manifest_path, worktree_host_path)
 
     # Step 3: Decide actions from the state machine.
     actions = decide(vm_state)
 
-    # Step 4: Dispatch.
-    mounts = target
+    # Step 4: Dispatch with the FULL manifest (not just primary + bridge), so a
+    # restart from worktree A keeps worktree B's mount alive too. Otherwise
+    # every cross-worktree `up` silently drops all other worktree shares.
+    mounts = manifest_read(manifest_path)
     for action in actions:
         if action == Action.CREATE:
             _action_create(project, mounts, log_path, key_path, headless=headless)
@@ -132,25 +128,36 @@ def ensure_attached(
 # ---------------------------------------------------------------------------
 
 
+def _running_mount_names(vm_name: str) -> set[str]:
+    """Return the directory-share names actually mounted in the running guest.
+
+    Empty set if the guest is unreachable or the shared-files dir is empty.
+    This is **ground truth** — the on-disk manifest can drift ahead of what
+    the currently-running VM actually has loaded.
+    """
+    result = vm.exec_capture(vm_name, ["ls", "/Volumes/My Shared Files/"])
+    if result.returncode != 0:
+        return set()
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
 def _read_state(
     project: ProjectConfig,
     manifest_path: Path,
     worktree: Path,
-    worktree_already_present: bool = False,
 ) -> VmState:
-    """Read current VM and manifest state.
-
-    ``worktree_already_present`` reflects whether the worktree path was in the
-    manifest BEFORE the current upsert.  A running VM loaded the old manifest at
-    boot, so ``mount_matches`` is True only when the path was already present —
-    meaning no restart is required to expose the mount inside the guest.
+    """Read current VM state. ``mount_matches`` reflects whether the running
+    guest actually has the worktree's mount loaded — queried via ``tart exec``,
+    not the on-disk manifest, because the manifest can drift ahead of the VM.
     """
     name = project.vm.name
     exists = vm.exists(name)
     running = exists and vm.is_running(name)
-    # A running VM has the OLD manifest loaded; we need a restart only when the
-    # worktree was not already mounted at boot time.
-    mount_matches = running and worktree_already_present
+    if running:
+        target_name = mount_name_for_path(project.slug, worktree)
+        mount_matches = target_name in _running_mount_names(name)
+    else:
+        mount_matches = False
     return VmState(exists=exists, running=running, mount_matches=mount_matches)
 
 

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -301,13 +301,22 @@ def _action_nothing(project: ProjectConfig) -> None:
 
 
 def _build_inject_command(pub: str) -> str:
-    """Build a shell command to idempotently inject a public key into authorized_keys."""
+    """Build a shell command to idempotently inject a public key into authorized_keys.
+
+    Uses ``set -e`` + an explicit ``grep || append`` pattern so the overall
+    exit code is unambiguous (0 = success).  The previous implementation
+    chained ``&& ... || ... && ...`` which has surprising left-associative
+    precedence and produced exit-1 even when the key was already present.
+    """
     quoted_pub = shlex.quote(pub)
     return (
-        "mkdir -p ~/.ssh && chmod 700 ~/.ssh && "
-        f"grep -Fqx -- {quoted_pub} ~/.ssh/authorized_keys 2>/dev/null || "
-        f"printf '%s\\n' {quoted_pub} >> ~/.ssh/authorized_keys && "
-        "chmod 600 ~/.ssh/authorized_keys"
+        "set -e; "
+        "mkdir -p ~/.ssh; "
+        "chmod 700 ~/.ssh; "
+        "touch ~/.ssh/authorized_keys; "
+        "chmod 600 ~/.ssh/authorized_keys; "
+        f"grep -Fqx -- {quoted_pub} ~/.ssh/authorized_keys "
+        f"|| printf '%s\\n' {quoted_pub} >> ~/.ssh/authorized_keys"
     )
 
 
@@ -333,8 +342,11 @@ def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
     inject_cmd = _build_inject_command(pub)
     result = vm.exec_capture(name, ["sh", "-c", inject_cmd])
     if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        detail = stderr or stdout or "(no output)"
         raise RemoTartError(
-            f"failed to install ssh public key into guest (exit {result.returncode})",
+            f"failed to install ssh public key into guest (exit {result.returncode}): {detail}",
             hint=f"check {vm_log_path(name)} and ensure the VM is fully booted",
         )
     done(f"SSH ready: ssh tart-{name}")

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -9,12 +9,14 @@ and the SSH config updated.  Ported from:
 from __future__ import annotations
 
 import shlex
+import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
 
 from remo_tart import launchd, ssh, vm
 from remo_tart.config import ProjectConfig
+from remo_tart.console import done, get_console, step
 from remo_tart.errors import RemoTartError
 from remo_tart.mount import (
     MountEntry,
@@ -53,8 +55,16 @@ def ensure_attached(
     repo_root: Path,
     project: ProjectConfig,
     worktree_host_path: Path,
+    *,
+    headless: bool = True,
 ) -> AttachOutcome:
-    """Make the VM running with the given worktree attached; idempotent."""
+    """Make the VM running with the given worktree attached; idempotent.
+
+    ``headless`` controls whether ``tart run`` is invoked with
+    ``--no-graphics``.  Default True (no UI window).  When False, a UI window
+    opens.  Note: ``headless`` is set at boot; an already-running VM keeps
+    whatever mode it was started with until the next restart.
+    """
     vm_name = project.vm.name
     manifest_path = mount_manifest_path(vm_name)
     log_path = vm_log_path(vm_name)
@@ -74,7 +84,7 @@ def ensure_attached(
         name=mount_name_for_path(project.slug, worktree_host_path),
         host_path=worktree_host_path,
     )
-    bridge_entry = git_root_bridge_entry(project.slug, repo_root / ".git")
+    bridge_entry = git_root_bridge_entry(project.slug, _resolve_git_common_dir(worktree_host_path))
     manifest_upsert(manifest_path, primary_entry)
     manifest_upsert(manifest_path, bridge_entry)
 
@@ -90,18 +100,22 @@ def ensure_attached(
     mounts = target
     for action in actions:
         if action == Action.CREATE:
-            _action_create(project, mounts, log_path, key_path)
+            _action_create(project, mounts, log_path, key_path, headless=headless)
         elif action == Action.UPDATE_MOUNT_AND_RESTART:
-            _action_update_mount_and_restart(project, mounts, log_path)
+            _action_update_mount_and_restart(project, mounts, log_path, headless=headless)
         elif action == Action.START:
-            _action_start(project, mounts, log_path)
+            _action_start(project, mounts, log_path, headless=headless)
         elif action == Action.ATTACH_MOUNT_AND_START:
-            _action_attach_mount_and_start(project, mounts, log_path)
+            _action_attach_mount_and_start(project, mounts, log_path, headless=headless)
         elif action == Action.NOTHING:
             _action_nothing(project)
 
-    # Step 5: Configure SSH for all actions except NOTHING.
-    if actions != [Action.NOTHING]:
+    # Step 5: Configure SSH unconditionally. All operations are idempotent
+    # (keypair generation skips if exists, managed block upsert replaces by VM
+    # name, include is added once, authorized_keys uses grep-skip-if-present).
+    # This makes the workflow self-healing if a prior `up` was Ctrl-C'd
+    # before SSH was configured.
+    if vm.is_running(project.vm.name):
         _configure_ssh(project, key_path)
 
     # Step 6: Return outcome with the final manifest.
@@ -140,17 +154,40 @@ def _read_state(
     return VmState(exists=exists, running=running, mount_matches=mount_matches)
 
 
+def _resolve_git_common_dir(worktree: Path) -> Path:
+    """Return the absolute git common dir for ``worktree``.
+
+    In a git worktree, ``<worktree>/.git`` is a *file* pointing at the main
+    checkout's ``.git`` directory.  Tart can only mount directories, so the
+    bridge mount must target the common dir, not the per-worktree gitdir.
+
+    Falls back to ``<worktree>/.git`` if ``git`` is unavailable or the path is
+    not a git repository (e.g. unit tests that pass an arbitrary tmp_path).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return worktree / ".git"
+    return (worktree / result.stdout.strip()).resolve()
+
+
 def _target_manifest(
     project: ProjectConfig,
     repo_root: Path,
     worktree: Path,
 ) -> list[MountEntry]:
     """Build the target mount list: primary worktree + git-root bridge."""
+    del repo_root  # use git's own opinion of where the common dir lives
     primary = MountEntry(
         name=mount_name_for_path(project.slug, worktree),
         host_path=worktree,
     )
-    bridge = git_root_bridge_entry(project.slug, repo_root / ".git")
+    bridge = git_root_bridge_entry(project.slug, _resolve_git_common_dir(worktree))
     return [primary, bridge]
 
 
@@ -159,6 +196,8 @@ def _action_create(
     mounts: list[MountEntry],
     log_path: Path,
     ssh_key_path: Path,
+    *,
+    headless: bool = True,
 ) -> None:
     """Create VM from base image, configure resources, and start it."""
     name = project.vm.name
@@ -171,9 +210,12 @@ def _action_create(
     # Remove any stale launchd registration for this label to avoid submit failure
     launchd.remove(label_str)
 
+    step(f"cloning base image {project.vm.base_image} as VM {name} (this can take several minutes)")
     vm.create(name, project.vm.base_image)
+    step(f"configuring VM resources (cpu={project.vm.cpu}, memory={project.vm.memory_gb}G)")
     vm.set_resources(name, project.vm.cpu, project.vm.memory_gb)
-    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=headless)
+    step(f"submitting launchd job {label_str} ({'headless' if headless else 'with display'})")
     launchd.submit(label_str, tart_args, log_path)
     _wait_for_guest_exec(name)
 
@@ -182,10 +224,13 @@ def _action_update_mount_and_restart(
     project: ProjectConfig,
     mounts: list[MountEntry],
     log_path: Path,
+    *,
+    headless: bool = True,
 ) -> None:
     """Stop the VM, update mounts, and restart."""
     name = project.vm.name
     label_str = launchd.label(name)
+    step(f"stopping VM {name} to update mounts")
     launchd.remove(label_str)
     _wait_for_stopped(name)
     # Also wait for launchctl to actually drop the label, to avoid submit conflict
@@ -193,7 +238,8 @@ def _action_update_mount_and_restart(
         if not launchd.job_present(label_str):
             break
         time.sleep(1)
-    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=headless)
+    step(f"restarting VM {name} with updated mounts ({'headless' if headless else 'with display'})")
     launchd.submit(label_str, tart_args, log_path)
     _wait_for_guest_exec(name)
 
@@ -202,6 +248,8 @@ def _action_start(
     project: ProjectConfig,
     mounts: list[MountEntry],
     log_path: Path,
+    *,
+    headless: bool = True,
 ) -> None:
     """Submit the VM to launchd and wait for it to be running."""
     name = project.vm.name
@@ -214,7 +262,8 @@ def _action_start(
     # Remove any stale launchd registration for this label to avoid submit failure
     launchd.remove(label_str)
 
-    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=headless)
+    step(f"starting VM {name} ({'headless' if headless else 'with display'})")
     launchd.submit(label_str, tart_args, log_path)
     _wait_for_guest_exec(name)
 
@@ -223,6 +272,8 @@ def _action_attach_mount_and_start(
     project: ProjectConfig,
     mounts: list[MountEntry],
     log_path: Path,
+    *,
+    headless: bool = True,
 ) -> None:
     """Mount is already upserted before state read; just submit and wait."""
     name = project.vm.name
@@ -235,16 +286,15 @@ def _action_attach_mount_and_start(
     # Remove any stale launchd registration for this label to avoid submit failure
     launchd.remove(label_str)
 
-    tart_args = vm.build_run_args(name, project.vm.network, mounts)
+    tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=headless)
+    step(f"attaching mount and starting VM {name} ({'headless' if headless else 'with display'})")
     launchd.submit(label_str, tart_args, log_path)
     _wait_for_guest_exec(name)
 
 
 def _action_nothing(project: ProjectConfig) -> None:
     """No-op — VM is already running with the correct mount."""
-    from remo_tart.console import console
-
-    console.print(
+    get_console().print(
         f"[dim]VM '{project.vm.name}' is already running with the correct mount. "
         "Nothing to do.[/dim]"
     )
@@ -264,6 +314,7 @@ def _build_inject_command(pub: str) -> str:
 def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
     """Configure SSH keypair, managed block, include directive, and authorized keys."""
     name = project.vm.name
+    step(f"configuring SSH for {name}")
 
     # 1. Generate keypair (idempotent).
     ssh.generate_keypair(key_path)
@@ -286,6 +337,7 @@ def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
             f"failed to install ssh public key into guest (exit {result.returncode})",
             hint=f"check {vm_log_path(name)} and ensure the VM is fully booted",
         )
+    done(f"SSH ready: ssh tart-{name}")
 
 
 # ---------------------------------------------------------------------------
@@ -293,32 +345,79 @@ def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _wait_for_guest_exec(vm_name: str, *, attempts: int = 90, interval: float = 2.0) -> None:
+def _wait_for_guest_exec(vm_name: str, *, attempts: int = 300, interval: float = 2.0) -> None:
     """Poll `tart exec true` until success. Raises RemoTartError on timeout.
 
-    This is stricter than `vm.is_running` — it waits for the guest agent to
-    respond, which is what downstream SSH key injection actually needs.
+    "Running" at the Tart/VZ layer just means the VM kernel started; macOS
+    inside still needs time to boot its launchd, network, and exec agent. We
+    surface intermediate signals (IP assignment, last log line) so the wait
+    isn't opaque.
     """
-    for _ in range(attempts):
-        # Quick readiness check — `tart exec <name> -- /usr/bin/true`
-        if not vm.is_running(vm_name):
-            time.sleep(interval)
-            continue
-        result = vm.exec_capture(vm_name, ["/usr/bin/true"])
-        if result.returncode == 0:
-            return
+    step(f"waiting for {vm_name} guest agent (macOS boot inside the VM)...")
+    get_console().print(
+        "[dim]   typical wait: 3-5 minutes (10+ on first boot). "
+        "Don't Ctrl-C — the connect step runs only after this finishes.[/dim]"
+    )
+    log_path = vm_log_path(vm_name)
+    last_ip: str | None = None
+    last_log_tail: str = ""
+    for i in range(attempts):
+        if vm.is_running(vm_name):
+            result = vm.exec_capture(vm_name, ["/usr/bin/true"])
+            if result.returncode == 0:
+                done(f"VM {vm_name} guest agent is ready")
+                return
+
+        elapsed = int((i + 1) * interval)
+        # IP assignment lands ~10-20s before the exec agent on macOS.
+        if last_ip is None:
+            ip = vm.ip_address(vm_name)
+            if ip:
+                last_ip = ip
+                get_console().print(f"[dim]  ...network up: {ip}[/dim]")
+
+        if elapsed and elapsed % 10 == 0:
+            running = "running" if vm.is_running(vm_name) else "VZ-still-booting"
+            tail = _last_log_line(log_path)
+            extra = ""
+            if tail and tail != last_log_tail:
+                last_log_tail = tail
+                extra = f' last log: "{tail[:80]}"'
+            get_console().print(f"[dim]  ...{vm_name} {running} ({elapsed}s elapsed){extra}[/dim]")
         time.sleep(interval)
     raise RemoTartError(
         f"timeout waiting for VM '{vm_name}' to be ready for exec",
-        hint=f"check {vm_log_path(vm_name)}",
+        hint=f"check {log_path}",
     )
+
+
+def _last_log_line(log_path: Path) -> str:
+    """Return the last non-empty line of a log file, or empty string."""
+    try:
+        with log_path.open("rb") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            if size == 0:
+                return ""
+            chunk = min(2048, size)
+            f.seek(size - chunk, 0)
+            data = f.read(chunk).decode("utf-8", errors="replace")
+        for line in reversed(data.splitlines()):
+            if line.strip():
+                return line.strip()
+    except OSError:
+        pass
+    return ""
 
 
 def _wait_for_stopped(name: str) -> None:
     """Poll until the VM has stopped, or raise RemoTartError on timeout."""
-    for _ in range(_WAIT_ATTEMPTS):
+    for i in range(_WAIT_ATTEMPTS):
         if not vm.is_running(name):
             return
+        elapsed = int((i + 1) * _WAIT_INTERVAL)
+        if elapsed and elapsed % 10 == 0:
+            get_console().print(f"[dim]  ...waiting for {name} to stop ({elapsed}s)[/dim]")
         time.sleep(_WAIT_INTERVAL)
     raise RemoTartError(
         f"timeout waiting for VM '{name}' to stop",

--- a/tools/remo-tart/tests/test_vm.py
+++ b/tools/remo-tart/tests/test_vm.py
@@ -87,6 +87,25 @@ def test_build_run_args_softnet() -> None:
     assert "--net-softnet" in args
 
 
+def test_build_run_args_does_not_emit_rw_option() -> None:
+    """Tart's --dir options are ro/tag=, NOT rw. Adding :rw makes Tart reject
+    the directory share with VZErrorDomain Code=2."""
+    mounts = [MountEntry("remo", Path("/r"))]
+    args = vm.build_run_args("remo-dev", network="shared", mounts=mounts)
+    assert "remo:/r" in args
+    assert not any(":rw" in a for a in args)
+
+
+def test_build_run_args_headless_by_default() -> None:
+    args = vm.build_run_args("remo-dev", network="shared", mounts=[])
+    assert "--no-graphics" in args
+
+
+def test_build_run_args_with_display_omits_no_graphics() -> None:
+    args = vm.build_run_args("remo-dev", network="shared", mounts=[], headless=False)
+    assert "--no-graphics" not in args
+
+
 @patch("subprocess.run")
 def test_create_invokes_tart_clone(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=0, stdout="", stderr="")

--- a/tools/remo-tart/tests/test_vm.py
+++ b/tools/remo-tart/tests/test_vm.py
@@ -147,6 +147,24 @@ def test_exec_capture_returns_completed_process(run: MagicMock) -> None:
 
 
 @patch("subprocess.run")
+def test_exec_capture_does_not_pass_double_dash_separator(run: MagicMock) -> None:
+    """``tart exec`` does not accept ``--`` as a separator — it treats ``--``
+    as a command name and fails with ``executable file not found``."""
+    run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    vm.exec_capture("remo-dev", ["echo", "hi"])
+    (called_argv,) = run.call_args[0]
+    assert "--" not in called_argv
+
+
+@patch("subprocess.run")
+def test_exec_interactive_does_not_pass_double_dash_separator(run: MagicMock) -> None:
+    run.return_value = MagicMock(returncode=0)
+    vm.exec_interactive("remo-dev", ["sh"])
+    (called_argv,) = run.call_args[0]
+    assert "--" not in called_argv
+
+
+@patch("subprocess.run")
 def test_ip_address_returns_stdout(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=0, stdout="10.0.0.2\n", stderr="")
     assert vm.ip_address("remo-dev") == "10.0.0.2"

--- a/tools/remo-tart/tests/test_worktree.py
+++ b/tools/remo-tart/tests/test_worktree.py
@@ -61,18 +61,24 @@ def test_missing_vm_triggers_create(
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
 @patch("remo_tart.worktree._action_nothing")
-def test_healthy_state_is_nothing_and_skips_ssh_reconfig(
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+def test_healthy_state_is_nothing_and_still_configures_ssh(
+    is_running: MagicMock,
     nothing: MagicMock,
     read: MagicMock,
     config_ssh: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
+    """SSH config is idempotent and runs unconditionally when the VM is running.
+
+    This makes the workflow self-healing if a prior `up` was Ctrl-C'd before
+    SSH was configured (e.g. interrupted during `_wait_for_guest_exec`).
+    """
     read.return_value = VmState(exists=True, running=True, mount_matches=True)
     ensure_attached(fake_repo, _cfg(), fake_repo)
     nothing.assert_called_once()
-    # NOTHING path does NOT re-configure SSH (no duplicate key injection)
-    config_ssh.assert_not_called()
+    config_ssh.assert_called_once()
 
 
 @patch("remo_tart.worktree._configure_ssh")
@@ -130,6 +136,56 @@ def _read_manifest(path: Path) -> list:
     from remo_tart.mount import manifest_read
 
     return manifest_read(path)
+
+
+def test_resolve_git_common_dir_uses_git_when_in_a_worktree(tmp_path: Path) -> None:
+    """In a real git worktree, ``<worktree>/.git`` is a *file* pointing at the
+    main checkout's ``.git`` directory.  ``_resolve_git_common_dir`` must
+    return the directory, not the file, so Tart can mount it.
+    """
+    import subprocess as sp
+
+    from remo_tart.worktree import _resolve_git_common_dir
+
+    main = tmp_path / "main"
+    main.mkdir()
+    git_env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "PATH": "/usr/bin:/bin",
+    }
+    sp.run(
+        ["git", "-C", str(main), "init", "--initial-branch=main"],
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+    sp.run(
+        ["git", "-C", str(main), "commit", "--allow-empty", "-m", "init"],
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+    worktree_path = tmp_path / "wt"
+    sp.run(
+        ["git", "-C", str(main), "worktree", "add", str(worktree_path)],
+        check=True,
+        capture_output=True,
+        env=git_env,
+    )
+
+    assert (worktree_path / ".git").is_file()  # worktree gitdir is a FILE
+    common = _resolve_git_common_dir(worktree_path)
+    assert common.is_dir()
+    assert common == (main / ".git").resolve()
+
+
+def test_resolve_git_common_dir_falls_back_when_not_a_git_repo(tmp_path: Path) -> None:
+    from remo_tart.worktree import _resolve_git_common_dir
+
+    assert _resolve_git_common_dir(tmp_path) == tmp_path / ".git"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/remo-tart/tests/test_worktree.py
+++ b/tools/remo-tart/tests/test_worktree.py
@@ -40,6 +40,7 @@ def fake_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
 @patch("remo_tart.worktree._action_create")
@@ -47,6 +48,7 @@ def test_missing_vm_triggers_create(
     create: MagicMock,
     read: MagicMock,
     config_ssh: MagicMock,
+    is_running: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
@@ -81,6 +83,7 @@ def test_healthy_state_is_nothing_and_still_configures_ssh(
     config_ssh.assert_called_once()
 
 
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
 @patch("remo_tart.worktree._action_update_mount_and_restart")
@@ -88,6 +91,7 @@ def test_running_with_mismatched_mount_triggers_update_and_restart(
     update: MagicMock,
     read: MagicMock,
     config_ssh: MagicMock,
+    is_running: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
@@ -97,6 +101,7 @@ def test_running_with_mismatched_mount_triggers_update_and_restart(
     config_ssh.assert_called_once()
 
 
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
 @patch("remo_tart.worktree._action_start")
@@ -104,6 +109,7 @@ def test_stopped_with_matching_mount_triggers_start(
     start: MagicMock,
     read: MagicMock,
     config_ssh: MagicMock,
+    is_running: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
@@ -121,6 +127,7 @@ def test_ensure_attached_upserts_primary_and_git_root(fake_home: Path, fake_repo
         patch("remo_tart.worktree._read_state") as read,
         patch("remo_tart.worktree._action_nothing"),
         patch("remo_tart.worktree._configure_ssh"),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
     ):
         read.return_value = VmState(exists=True, running=True, mount_matches=True)
         ensure_attached(fake_repo, _cfg(), fake_repo)
@@ -293,11 +300,13 @@ def test_configure_ssh_raises_when_guest_injection_fails(
 # ---------------------------------------------------------------------------
 
 
+@patch("remo_tart.worktree.vm.ip_address", return_value=None)
 @patch("remo_tart.worktree.vm.exec_capture")
 @patch("remo_tart.worktree.vm.is_running", return_value=True)
 def test_wait_for_guest_exec_polls_exec_capture(
     is_running: MagicMock,
     exec_capture: MagicMock,
+    ip_address: MagicMock,
 ) -> None:
     from remo_tart.worktree import _wait_for_guest_exec
 
@@ -307,11 +316,13 @@ def test_wait_for_guest_exec_polls_exec_capture(
     exec_capture.assert_called_with("remo-dev", ["/usr/bin/true"])
 
 
+@patch("remo_tart.worktree.vm.ip_address", return_value=None)
 @patch("remo_tart.worktree.vm.exec_capture")
 @patch("remo_tart.worktree.vm.is_running", return_value=True)
 def test_wait_for_guest_exec_raises_on_timeout(
     is_running: MagicMock,
     exec_capture: MagicMock,
+    ip_address: MagicMock,
 ) -> None:
     from remo_tart.errors import RemoTartError
     from remo_tart.worktree import _wait_for_guest_exec
@@ -363,6 +374,7 @@ def test_attach_outcome_has_primary_and_immutable_fields(fake_home: Path, fake_r
         patch("remo_tart.worktree._read_state") as read,
         patch("remo_tart.worktree._action_nothing"),
         patch("remo_tart.worktree._configure_ssh"),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
     ):
         read.return_value = VmState(exists=True, running=True, mount_matches=True)
         outcome = ensure_attached(fake_repo, _cfg(), fake_repo)


### PR DESCRIPTION
## Summary

Five real bugs that combined to make `remo-tart up` fail end-to-end on a fresh VM (or any state requiring a boot), plus progress UX so the long boot wait isn't opaque.

### The bugs

1. **`tart exec --` separator** (`05839bf`) — root cause hiding behind everything else. `tart exec <vm> <cmd>` does NOT take `--`; we were generating `tart exec <vm> -- sh -c \"...\"` and tart treated `--` as the command name (`exec: \"--\": executable file not found`). This made `_wait_for_guest_exec` ALWAYS return 1 regardless of guest state — every \"timeout waiting for VM ready for exec\" was actually this. Bumping the timeout was treating a symptom; this is the fix.

2. **`--dir :rw`** (`f59676f`) — Tart's `--dir` options are `ro` or `tag=<TAG>`. There is no `rw` (rw is the default). Passing `name:path:rw` makes Tart reject the share with `VZErrorDomain Code=2 directory sharing config invalid` and the VM never boots.

3. **Git worktree bridge** (`f076a99`) — in a git worktree `<wt>/.git` is a *file*, not a directory; Tart only mounts directories. Use `git rev-parse --git-common-dir` to point the bridge at the main checkout's `.git/`.

4. **`_action_nothing` ImportError** (`f076a99`) — `from remo_tart.console import console` was broken; it should be `get_console()`.

5. **SSH self-heal** (`f076a99`) — if a previous `up` was Ctrl-C'd before `_configure_ssh` ran, the next `up` lands in NOTHING and skipped SSH, so VS Code couldn't connect. All SSH ops are idempotent, so run them whenever the VM is running.

### Quality-of-life

- **Progress UX** (`bb4c32f`) — every action prints a banner; `_wait_for_guest_exec` warns \"3-5 minutes, don't Ctrl-C\" up front and prints elapsed every 10s; SSH/connect steps emit ✓ on completion. Surfaces `tart ip` once it returns and tails the VM log when it has new content.
- **`--display` flag** (`f59676f` + `bb4c32f`) — VM defaults to headless (`--no-graphics`); `remo-tart up --display` opens a UI window for the rare cases (boot debugging, GUI work).
- **Wait timeout 180s → 600s** (`f076a99`) — orthogonal to bug #1; macOS Tahoe first-boot inside the VM legitimately takes 3-5+ min; the old 180s was tight even with a working wait loop.

## Test plan

- [x] `uv run pytest -v` — 160 passed (was 158; +2 regression tests pinning `--` absence)
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `remo-tart up vscode` from a worktree — boot completes, SSH installs, VS Code opens (verified end-to-end on macOS Tahoe with Tart bridged:en0)
- [x] `remo-tart up vscode` second run (NOTHING path) — \`_configure_ssh\` runs idempotently, VS Code opens immediately
- [x] `tart exec remo-dev /usr/bin/true` returns 0 from inside Python via \`vm.exec_capture\` (regression test pins \`--\` absence)

## Notes

- This unblocks PR 2/PR 3's Python CLI on real hardware. Nothing about the Python rewrite was wrong in concept — these are 5 small mistakes in the bash-to-Python port.
- The \"umbrella mount\" speedup (mount project root once instead of per-worktree, eliminating restarts when adding worktrees) is tracked separately as a future PR — orthogonal to this hotfix.