### PR TITLE
feat(remo-tart): umbrella mount + minimal pool

### DIFF
--- a/tools/remo-tart/src/remo_tart/cli.py
+++ b/tools/remo-tart/src/remo_tart/cli.py
@@ -43,43 +43,10 @@ def _load_cfg(ctx: click.Context):  # type: ignore[return]
     return repo, project
 
 
-# ---------------------------------------------------------------------------
-# CLI-internal helpers
-# ---------------------------------------------------------------------------
+def _resolve_pool(project, pool_name: str | None):
+    from remo_tart.pool import resolve_pool
 
-
-def _resolve_primary_mount(
-    entries: list,  # type: ignore[type-arg]
-    cwd: Path,
-) -> object:
-    """Return the mount entry whose host_path matches cwd, or the first non-bridge entry.
-
-    This is a CLI-specific helper — not exported from mount.py.
-    """
-    if not entries:
-        raise RemoTartError(
-            "no mounts attached to this VM",
-            hint="run `remo-tart use` from this worktree to attach it",
-        )
-    cwd_resolved = cwd.resolve()
-    for entry in entries:
-        try:
-            if entry.host_path.resolve() == cwd_resolved:
-                return entry
-        except OSError:
-            continue
-    # No exact match — fall back to first non-git-root entry, but warn
-    non_bridge = [e for e in entries if not e.name.endswith("-git-root")]
-    if non_bridge:
-        get_console().print(
-            f"[yellow]warning:[/yellow] cwd {cwd} does not match any mount; "
-            f"using mount '{non_bridge[0].name}'"
-        )
-        return non_bridge[0]
-    raise RemoTartError(
-        f"cwd {cwd} is not a recorded mount and no non-bridge mount exists",
-        hint="run `remo-tart use` from this worktree to attach it",
-    )
+    return resolve_pool(project, pool_name)
 
 
 # ---------------------------------------------------------------------------
@@ -107,8 +74,15 @@ def main(ctx: click.Context, verbose: int) -> None:
     is_flag=True,
     help="Boot with a UI window. Triggers a restart if VM is currently headless.",
 )
+@click.option(
+    "--pool",
+    "pool_name",
+    type=str,
+    default=None,
+    help="Pool (VM identity) to join; defaults to project.vm.name.",
+)
 @click.pass_context
-def up(ctx: click.Context, mode: str, display: bool) -> None:
+def up(ctx: click.Context, mode: str, display: bool, pool_name: str | None) -> None:
     """Attach the current worktree, ensure the VM is running, and connect.
 
     By default the VM runs headless (no UI window). Use ``--display`` if you
@@ -117,20 +91,27 @@ def up(ctx: click.Context, mode: str, display: bool) -> None:
     """
     from remo_tart.console import done as _done
     from remo_tart.console import step as _step
+    from remo_tart.paths import git_worktree_root
 
     repo, project = _load_cfg(ctx)
-    cwd = Path.cwd()
-    _step(f"up({mode}) for worktree {cwd}")
-    outcome = worktree.ensure_attached(repo, project, cwd, headless=not display)
+    wt_root = git_worktree_root(Path.cwd())
+    _step(f"up({mode}) for worktree {wt_root}")
+    outcome = worktree.ensure_attached(
+        repo,
+        project,
+        wt_root,
+        pool_name=pool_name,
+        headless=not display,
+    )
     _done(f"actions: {', '.join(a.name for a in outcome.actions)}")
-    name = project.vm.name
+    name = outcome.attachment.pool_name
     _step(f"connecting via {mode}")
     if mode == "cli":
         code = _connect.connect_cli(name, project.vm.guest_user)
     elif mode == "vscode":
-        code = _connect.connect_vscode(name, project.vm.guest_user, outcome.primary)
+        code = _connect.connect_vscode(name, project.vm.guest_user, outcome.attachment)
     else:  # cursor
-        code = _connect.connect_cursor(name, project.vm.guest_user, outcome.primary)
+        code = _connect.connect_cursor(name, project.vm.guest_user, outcome.attachment)
     ctx.exit(code)
 
 
@@ -139,14 +120,20 @@ def up(ctx: click.Context, mode: str, display: bool) -> None:
 
 @main.command()
 @click.argument("worktree_path", required=False, metavar="PATH")
+@click.option("--pool", "pool_name", type=str, default=None, help="Pool to join.")
 @click.pass_context
-def use(ctx: click.Context, worktree_path: str | None) -> None:
+def use(ctx: click.Context, worktree_path: str | None, pool_name: str | None) -> None:
     """Attach a worktree to the VM (mount + restart if needed)."""
+    from remo_tart.paths import git_worktree_root
+
     repo, project = _load_cfg(ctx)
-    path = Path(worktree_path).resolve() if worktree_path else Path.cwd()
-    outcome = worktree.ensure_attached(repo, project, path)
+    if worktree_path:
+        path = git_worktree_root(Path(worktree_path).resolve())
+    else:
+        path = git_worktree_root(Path.cwd())
+    outcome = worktree.ensure_attached(repo, project, path, pool_name=pool_name)
     get_console().print(
-        f"[green]Attached[/green] {outcome.primary.name} "
+        f"[green]Attached[/green] {outcome.attachment.pool_name} "
         f"(actions: {', '.join(a.name for a in outcome.actions)})"
     )
 
@@ -157,11 +144,13 @@ def use(ctx: click.Context, worktree_path: str | None) -> None:
     is_flag=True,
     help="Boot with a UI window. Default is headless.",
 )
+@click.option("--pool", "pool_name", type=str, default=None, help="Pool to start.")
 @click.pass_context
-def start(ctx: click.Context, display: bool) -> None:
+def start(ctx: click.Context, display: bool, pool_name: str | None) -> None:
     """Start the VM without changing mounts or connecting."""
     _repo, project = _load_cfg(ctx)
-    name = project.vm.name
+    pool = _resolve_pool(project, pool_name)
+    name = pool.name
     if not vm.exists(name):
         raise RemoTartError(
             "vm does not exist",
@@ -172,7 +161,6 @@ def start(ctx: click.Context, display: bool) -> None:
     manifest_path = mount_manifest_path(name)
     mounts = manifest_read(manifest_path)
     launchd.remove(label)
-    # Truncate log to avoid confusion with stale output
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("")
     tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=not display)
@@ -181,26 +169,33 @@ def start(ctx: click.Context, display: bool) -> None:
 
 @main.command()
 @click.argument("mode", type=click.Choice(["cli", "vscode", "cursor"]), default="cli")
+@click.option("--pool", "pool_name", type=str, default=None, help="Pool to connect to.")
 @click.pass_context
-def connect(ctx: click.Context, mode: str) -> None:
+def connect(ctx: click.Context, mode: str, pool_name: str | None) -> None:
     """Connect to the running VM (cli / vscode / cursor)."""
-    _repo, project = _load_cfg(ctx)
-    name = project.vm.name
+    from remo_tart.paths import git_worktree_root
+    from remo_tart.worktree import WorktreeAttachment, guest_path_for_worktree
+
+    repo, project = _load_cfg(ctx)
+    pool = _resolve_pool(project, pool_name)
+    name = pool.name
     if not vm.is_running(name):
         raise RemoTartError(
             f"vm is not running: {name}",
             hint="run `remo-tart up` to start and connect, or `remo-tart start` to only start",
         )
-    # Find the primary mount: the one whose host_path matches cwd or first entry
-    manifest_path = mount_manifest_path(name)
-    entries = mount.manifest_read(manifest_path)
-    primary = _resolve_primary_mount(entries, Path.cwd())
+    wt_root = git_worktree_root(Path.cwd())
+    attachment = WorktreeAttachment(
+        pool_name=name,
+        host_path=wt_root,
+        guest_path=guest_path_for_worktree(name, repo, wt_root),
+    )
     if mode == "cli":
         code = _connect.connect_cli(name, project.vm.guest_user)
     elif mode == "vscode":
-        code = _connect.connect_vscode(name, project.vm.guest_user, primary)
+        code = _connect.connect_vscode(name, project.vm.guest_user, attachment)
     else:  # cursor
-        code = _connect.connect_cursor(name, project.vm.guest_user, primary)
+        code = _connect.connect_cursor(name, project.vm.guest_user, attachment)
     ctx.exit(code)
 
 
@@ -209,12 +204,16 @@ def connect(ctx: click.Context, mode: str) -> None:
 
 @main.command()
 @click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
+@click.option("--pool", "pool_name", type=str, default=None, help="Pool to inspect.")
 @click.pass_context
-def status(ctx: click.Context, as_json: bool) -> None:
+def status(ctx: click.Context, as_json: bool, pool_name: str | None) -> None:
     """Show VM status."""
+    from remo_tart.paths import git_worktree_root
+
     repo, project = _load_cfg(ctx)
-    name = project.vm.name
-    data = _status.collect(name, repo, Path.cwd())
+    pool = _resolve_pool(project, pool_name)
+    wt_root = git_worktree_root(Path.cwd())
+    data = _status.collect(pool.name, repo, wt_root)
     output = _status.render_json(data) if as_json else _status.render_human(data)
     get_console().print(output)
 
@@ -237,11 +236,13 @@ def doctor(ctx: click.Context) -> None:
 
 @main.command(context_settings={"ignore_unknown_options": True})
 @click.argument("ssh_args", nargs=-1, type=click.UNPROCESSED)
+@click.option("--pool", "pool_name", type=str, default=None, help="Pool to ssh into.")
 @click.pass_context
-def ssh(ctx: click.Context, ssh_args: tuple[str, ...]) -> None:
+def ssh(ctx: click.Context, ssh_args: tuple[str, ...], pool_name: str | None) -> None:
     """Open an SSH session or run a command inside the VM."""
     _repo, project = _load_cfg(ctx)
-    name = project.vm.name
+    pool = _resolve_pool(project, pool_name)
+    name = pool.name
     if not vm.is_running(name):
         raise RemoTartError(
             f"vm is not running: {name}",
@@ -257,11 +258,13 @@ def ssh(ctx: click.Context, ssh_args: tuple[str, ...]) -> None:
 
 @main.command()
 @click.option("--force", is_flag=True, help="Skip confirmation.")
+@click.option("--pool", "pool_name", type=str, default=None, help="Pool to destroy.")
 @click.pass_context
-def destroy(ctx: click.Context, force: bool) -> None:
+def destroy(ctx: click.Context, force: bool, pool_name: str | None) -> None:
     """Destroy the VM."""
     _repo, project = _load_cfg(ctx)
-    name = project.vm.name
+    pool = _resolve_pool(project, pool_name)
+    name = pool.name
     if not force:
         confirmed = click.confirm(f"Destroy VM '{name}'? This cannot be undone.", default=False)
         if not confirmed:
@@ -272,7 +275,6 @@ def destroy(ctx: click.Context, force: bool) -> None:
         vm.delete(name)
     _ssh.remove_managed_block(ssh_include_path(), name)
     _ssh.remove_include_from_user_config(user_ssh_config_path(), ssh_include_path())
-    # Optionally remove the SSH key file
     key = ssh_key_path(name)
     if key.exists():
         key.unlink(missing_ok=True)
@@ -283,12 +285,16 @@ def destroy(ctx: click.Context, force: bool) -> None:
 
 @main.command(name="clean-worktree")
 @click.argument("path", required=False)
+@click.option("--pool", "pool_name", type=str, default=None, help="Pool whose manifest to edit.")
 @click.pass_context
-def clean_worktree(ctx: click.Context, path: str | None) -> None:
+def clean_worktree(ctx: click.Context, path: str | None, pool_name: str | None) -> None:
     """Remove a worktree from the mount manifest."""
+    from remo_tart.paths import git_worktree_root
+
     _repo, project = _load_cfg(ctx)
-    resolved = Path(path).resolve() if path else Path.cwd()
-    manifest_path = mount_manifest_path(project.vm.name)
+    pool = _resolve_pool(project, pool_name)
+    resolved = git_worktree_root(Path(path).resolve()) if path else git_worktree_root(Path.cwd())
+    manifest_path = mount_manifest_path(pool.name)
     mount_name = mount_name_for_path(project.slug, resolved)
     mount.manifest_remove(manifest_path, mount_name)
     get_console().print(f"[green]Removed[/green] mount entry '{mount_name}' from manifest.")
@@ -298,12 +304,13 @@ def clean_worktree(ctx: click.Context, path: str | None) -> None:
 @click.pass_context
 def bootstrap(ctx: click.Context) -> None:
     """First-time VM setup (create + provision)."""
+    from remo_tart.paths import git_worktree_root
+
     get_console().print("[bold]First-time setup[/bold] — creating and provisioning VM…")
     repo, project = _load_cfg(ctx)
-    cwd = Path.cwd()
-    worktree.ensure_attached(repo, project, cwd)
-    name = project.vm.name
-    code = _connect.connect_cli(name, project.vm.guest_user)
+    wt_root = git_worktree_root(Path.cwd())
+    outcome = worktree.ensure_attached(repo, project, wt_root)
+    code = _connect.connect_cli(outcome.attachment.pool_name, project.vm.guest_user)
     ctx.exit(code)
 
 

--- a/tools/remo-tart/src/remo_tart/connect.py
+++ b/tools/remo-tart/src/remo_tart/connect.py
@@ -4,22 +4,13 @@ from __future__ import annotations
 
 import subprocess
 
-from remo_tart.mount import MountEntry
 from remo_tart.ssh import ssh_alias
-
-# Guest-side shared folder root (tart virtiofs / directory-share mount point).
-_GUEST_SHARED_ROOT = "/Volumes/My Shared Files"
+from remo_tart.worktree import WorktreeAttachment
 
 
 def connect_cli(vm_name: str, guest_user: str) -> int:
-    """Drop into an interactive SSH shell on *vm_name*.
-
-    Uses the SSH alias ``tart-<vm-name>`` (baked into the SSH config by
-    :func:`remo_tart.ssh.upsert_managed_block`).  *guest_user* is kept for
-    future use when we may bypass the alias and connect directly.
-
-    Returns the ssh process exit code.
-    """
+    """Drop into an interactive SSH shell on *vm_name*."""
+    del guest_user  # ssh alias already encodes the user
     alias = ssh_alias(vm_name)
     return subprocess.run(["ssh", alias], check=False).returncode
 
@@ -27,20 +18,14 @@ def connect_cli(vm_name: str, guest_user: str) -> int:
 def connect_vscode(
     vm_name: str,
     guest_user: str,
-    mount: MountEntry,
+    attachment: WorktreeAttachment,
     *,
     new_window: bool = False,
 ) -> int:
-    """Open *mount* in VS Code via the SSH remote extension.
-
-    Builds a ``vscode-remote://ssh-remote+<alias>/<guest-path>`` URI and
-    passes it to the ``code`` CLI.  *guest_user* is kept for future use.
-
-    Returns the ``code`` process exit code.
-    """
+    """Open the worktree referenced by *attachment* in VS Code via SSH-remote."""
+    del guest_user
     alias = ssh_alias(vm_name)
-    guest_path = f"{_GUEST_SHARED_ROOT}/{mount.name}"
-    uri = f"vscode-remote://ssh-remote+{alias}{guest_path}"
+    uri = f"vscode-remote://ssh-remote+{alias}{attachment.guest_path}"
     window_flag = "--new-window" if new_window else "--reuse-window"
     argv = ["code", window_flag, "--folder-uri", uri]
     return subprocess.run(argv, check=False).returncode
@@ -49,20 +34,14 @@ def connect_vscode(
 def connect_cursor(
     vm_name: str,
     guest_user: str,
-    mount: MountEntry,
+    attachment: WorktreeAttachment,
     *,
     new_window: bool = False,
 ) -> int:
-    """Open *mount* in Cursor via the SSH remote extension.
-
-    Identical to :func:`connect_vscode` but invokes ``cursor`` instead of
-    ``code``.  Cursor accepts the same ``vscode-remote://`` URI scheme.
-
-    Returns the ``cursor`` process exit code.
-    """
+    """Open the worktree referenced by *attachment* in Cursor."""
+    del guest_user
     alias = ssh_alias(vm_name)
-    guest_path = f"{_GUEST_SHARED_ROOT}/{mount.name}"
-    uri = f"vscode-remote://ssh-remote+{alias}{guest_path}"
+    uri = f"vscode-remote://ssh-remote+{alias}{attachment.guest_path}"
     window_flag = "--new-window" if new_window else "--reuse-window"
     argv = ["cursor", window_flag, "--folder-uri", uri]
     return subprocess.run(argv, check=False).returncode

--- a/tools/remo-tart/src/remo_tart/mount.py
+++ b/tools/remo-tart/src/remo_tart/mount.py
@@ -1,4 +1,4 @@
-"""Mount manifest management, name derivation, and guest bridge script generation."""
+"""Mount manifest management and name derivation."""
 
 from __future__ import annotations
 
@@ -8,9 +8,6 @@ import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-
-# Guest-side shared folder root (tart virtiofs mount point).
-_SHARED_ROOT = "/Volumes/My Shared Files"
 
 
 @dataclass(frozen=True)
@@ -123,11 +120,6 @@ def mount_name_for_path(project_slug: str, host_path: Path) -> str:
     return f"{project_slug}-{worktree_slug}"
 
 
-def git_root_bridge_entry(project_slug: str, git_root: Path) -> MountEntry:
-    """Return a ``MountEntry`` for the git-root bridge mount."""
-    return MountEntry(f"{project_slug}-git-root", git_root)
-
-
 def parse_mount_spec(project_slug: str, spec: str) -> MountEntry:
     """Parse a mount spec of the form ``host[:name[:guest-root]]``.
 
@@ -142,87 +134,3 @@ def parse_mount_spec(project_slug: str, spec: str) -> MountEntry:
     else:
         name = mount_name_for_path(project_slug, host_path)
     return MountEntry(name, host_path)
-
-
-# ---------------------------------------------------------------------------
-# Guest bridge script
-# ---------------------------------------------------------------------------
-
-
-def guest_bridge_script(
-    entries: list[MountEntry],
-    git_root_name: str,
-    *,
-    guest_password: str,
-) -> str:
-    """Return a bash script that wires up ``.git`` symlinks inside the guest.
-
-    For each entry in *entries* that is NOT the git-root bridge itself, the
-    script creates a symlink:
-
-        /Volumes/My Shared Files/<name>/.git
-            → /Volumes/My Shared Files/<git_root_name>
-
-    This mirrors the logic of ``remo_tart_guest_git_root_bridge_script`` in
-    ``scripts/tart/common.sh`` (lines 418-450).
-    """
-    lines: list[str] = [
-        "#!/usr/bin/env bash",
-        "set -euo pipefail",
-        "",
-    ]
-
-    git_root_mount = f"{_SHARED_ROOT}/{git_root_name}"
-
-    for entry in entries:
-        if entry.name == git_root_name:
-            continue
-
-        guest_git_root = f"{_SHARED_ROOT}/{entry.name}/.git"
-        guest_bridge_source = git_root_mount
-        guest_git_parent = f"{_SHARED_ROOT}/{entry.name}"
-
-        lines += [
-            f"guest_git_root={_shell_quote(guest_git_root)}",
-            f"guest_bridge_source={_shell_quote(guest_bridge_source)}",
-            f"guest_git_parent={_shell_quote(guest_git_parent)}",
-            'if [[ -L "${guest_git_parent}" ]]; then',
-            (
-                f'    printf "%s\\n" {_shell_quote(guest_password)}'
-                f" | sudo -S rm -f {_shell_quote(guest_git_parent)}"
-            ),
-            "fi",
-            'if [[ -e "${guest_git_parent}" && ! -d "${guest_git_parent}" ]]; then',
-            '    echo "guest git parent exists and is not a directory: ${guest_git_parent}" >&2',
-            "    exit 1",
-            "fi",
-            'if [[ -L "${guest_git_root}" ]]; then',
-            '    current_target="$(readlink "${guest_git_root}")"',
-            '    if [[ "${current_target}" == "${guest_bridge_source}" ]]; then',
-            "        exit 0",
-            "    fi",
-            "fi",
-            'if [[ -e "${guest_git_root}" && ! -L "${guest_git_root}" ]]; then',
-            (
-                '    echo "guest git root bridge target already exists'
-                ' and is not a symlink: ${guest_git_root}" >&2'
-            ),
-            "    exit 1",
-            "fi",
-            (
-                f'printf "%s\\n" {_shell_quote(guest_password)}'
-                f" | sudo -S mkdir -p {_shell_quote(guest_git_parent)}"
-            ),
-            (
-                f'printf "%s\\n" {_shell_quote(guest_password)} | sudo -S ln -sfn'
-                f" {_shell_quote(guest_bridge_source)} {_shell_quote(guest_git_root)}"
-            ),
-            "",
-        ]
-
-    return "\n".join(lines)
-
-
-def _shell_quote(s: str) -> str:
-    """Minimal single-quote shell escaping for paths."""
-    return "'" + s.replace("'", "'\\''") + "'"

--- a/tools/remo-tart/src/remo_tart/paths.py
+++ b/tools/remo-tart/src/remo_tart/paths.py
@@ -49,3 +49,24 @@ def find_repo_root(start: Path | None = None) -> Path:
         "unable to find the Remo repo root from the current working directory",
         hint="run remo-tart from inside a Tart-managed project (.tart/project.toml must exist)",
     )
+
+
+def git_worktree_root(path: Path) -> Path:
+    """Return the worktree root containing *path*, or *path* if not in a repo.
+
+    Uses ``git rev-parse --show-toplevel``. For the main checkout this is the
+    repo root; for a linked worktree (e.g. under ``.worktrees/<name>``) it is
+    the worktree's own top-level directory.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return path.resolve()
+    return Path(result.stdout.strip()).resolve()

--- a/tools/remo-tart/src/remo_tart/pool.py
+++ b/tools/remo-tart/src/remo_tart/pool.py
@@ -1,0 +1,47 @@
+"""Pool resolution.
+
+A *pool* is a named Tart VM identity. Every worktree's `up` joins exactly one
+pool. The pool name parameterises the VM name (`tart` CLI), launchd label,
+SSH key file, log path, and mount manifest path.
+
+Default pool name is the project's configured ``vm.name`` so existing
+single-VM setups keep working unchanged. ``--pool <name>`` opts a worktree
+into a distinct pool (i.e. a distinct VM) for parallel/isolated work.
+
+VM image, CPU, memory, and network are still read from the project config —
+this minimum-viable pool is purely a VM-identity namespace. Cross-project
+pools and per-pool config persistence are intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from remo_tart.config import ProjectConfig
+from remo_tart.errors import RemoTartError
+
+_VALID_NAME = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class PoolConfig:
+    """Resolved pool identity for one ``ensure_attached`` invocation."""
+
+    name: str
+
+
+def resolve_pool(project: ProjectConfig, pool_name: str | None) -> PoolConfig:
+    """Return the resolved pool for *project*.
+
+    *pool_name* of ``None`` falls back to ``project.vm.name`` (the default
+    pool, preserving backward compatibility). Any other value is validated
+    against the same character class Tart accepts for VM names.
+    """
+    name = pool_name if pool_name is not None else project.vm.name
+    if not name or not _VALID_NAME.match(name):
+        raise RemoTartError(
+            f"invalid pool name: {name!r}",
+            hint="pool names must start with [A-Za-z0-9] and contain only [A-Za-z0-9._-]",
+        )
+    return PoolConfig(name=name)

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -8,8 +8,8 @@ and the SSH config updated.  Ported from:
 
 from __future__ import annotations
 
+import os
 import shlex
-import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,11 +20,8 @@ from remo_tart.console import done, get_console, step
 from remo_tart.errors import RemoTartError
 from remo_tart.mount import (
     MountEntry,
-    git_root_bridge_entry,
-    manifest_prune_stale,
     manifest_read,
-    manifest_upsert,
-    mount_name_for_path,
+    manifest_write,
 )
 from remo_tart.paths import (
     mount_manifest_path,
@@ -33,6 +30,7 @@ from remo_tart.paths import (
     user_ssh_config_path,
     vm_log_path,
 )
+from remo_tart.pool import PoolConfig, resolve_pool
 from remo_tart.state import Action, VmState, decide
 
 _WAIT_INTERVAL = 2  # seconds between polls
@@ -44,11 +42,58 @@ _WAIT_ATTEMPTS = 90  # maximum polling attempts (~3 minutes total)
 # ---------------------------------------------------------------------------
 
 
+_GUEST_SHARED_ROOT = "/Volumes/My Shared Files"
+
+
+@dataclass(frozen=True)
+class WorktreeAttachment:
+    """The worktree the user just attached to the pool.
+
+    ``host_path`` is the host directory (the git worktree top).
+    ``guest_path`` is the corresponding absolute path inside the VM, computed
+    as ``<shared_root>/<pool_name>/<rel-from-repo-root>``. Editors and connect
+    handlers open ``guest_path``; ``host_path`` is exposed for status/logging.
+    """
+
+    pool_name: str
+    host_path: Path
+    guest_path: str
+
+
+def guest_path_for_worktree(pool_name: str, repo_root: Path, worktree: Path) -> str:
+    """Compute the guest absolute path of *worktree* under the umbrella.
+
+    Raises :class:`RemoTartError` if *worktree* is not inside *repo_root* —
+    cross-project pools are out of scope for this MVP.
+    """
+    repo_resolved = repo_root.resolve()
+    wt_resolved = worktree.resolve()
+    try:
+        rel = wt_resolved.relative_to(repo_resolved)
+    except ValueError as err:
+        raise RemoTartError(
+            f"worktree {wt_resolved} is not under repo root {repo_resolved}",
+            hint="cross-repo pool membership is not yet supported",
+        ) from err
+    if str(rel) == ".":
+        return f"{_GUEST_SHARED_ROOT}/{pool_name}"
+    return f"{_GUEST_SHARED_ROOT}/{pool_name}/{rel.as_posix()}"
+
+
 @dataclass(frozen=True)
 class AttachOutcome:
+    """Result of ``ensure_attached``.
+
+    ``actions`` is the state-machine output for diagnostic display.
+    ``manifest`` is the post-attach mount list (always one entry: the umbrella).
+    ``attachment`` carries the worktree the user attached: host path + guest
+    path under the umbrella. Connect handlers should read ``attachment``;
+    ``manifest`` is for status reporting.
+    """
+
     actions: tuple[Action, ...]
     manifest: tuple[MountEntry, ...]
-    primary: MountEntry
+    attachment: WorktreeAttachment
 
 
 def ensure_attached(
@@ -56,70 +101,55 @@ def ensure_attached(
     project: ProjectConfig,
     worktree_host_path: Path,
     *,
+    pool_name: str | None = None,
     headless: bool = True,
 ) -> AttachOutcome:
-    """Make the VM running with the given worktree attached; idempotent.
+    """Make the pool VM running with the umbrella mounted; idempotent.
 
-    ``headless`` controls whether ``tart run`` is invoked with
-    ``--no-graphics``.  Default True (no UI window).  When False, a UI window
-    opens.  Note: ``headless`` is set at boot; an already-running VM keeps
-    whatever mode it was started with until the next restart.
+    Always mounts ``repo_root`` once as ``<pool.name>`` — the umbrella. Adding
+    a new worktree under ``repo_root`` requires no manifest change and no VM
+    restart, so cross-worktree ``up`` collapses to ``NOTHING`` after the first
+    boot.
     """
-    vm_name = project.vm.name
-    manifest_path = mount_manifest_path(vm_name)
-    log_path = vm_log_path(vm_name)
-    key_path = ssh_key_path(vm_name)
+    pool = resolve_pool(project, pool_name)
+    manifest_path = mount_manifest_path(pool.name)
+    log_path = vm_log_path(pool.name)
+    key_path = ssh_key_path(pool.name)
 
-    # Step 1: Prune stale entries, then upsert the primary + git-root bridge.
-    manifest_prune_stale(manifest_path)
+    _normalize_worktree_gitdirs(repo_root)
 
-    primary_entry = MountEntry(
-        name=mount_name_for_path(project.slug, worktree_host_path),
-        host_path=worktree_host_path,
-    )
-    bridge_entry = git_root_bridge_entry(project.slug, _resolve_git_common_dir(worktree_host_path))
-    manifest_upsert(manifest_path, primary_entry)
-    manifest_upsert(manifest_path, bridge_entry)
+    umbrella_entry = MountEntry(name=pool.name, host_path=repo_root.resolve())
+    manifest_write(manifest_path, [umbrella_entry])
 
-    # Step 2: Read VM state.  ``mount_matches`` is computed against the
-    # *running* VM's actual mounts (queried via tart exec), not the on-disk
-    # manifest — the manifest can drift ahead of the running VM if mounts
-    # were upserted between boots.
-    vm_state = _read_state(project, manifest_path, worktree_host_path)
+    vm_state = _read_state(pool)
 
-    # Step 3: Decide actions from the state machine.
-    actions = decide(vm_state)
-
-    # Step 4: Dispatch with the FULL manifest (not just primary + bridge), so a
-    # restart from worktree A keeps worktree B's mount alive too. Otherwise
-    # every cross-worktree `up` silently drops all other worktree shares.
     mounts = manifest_read(manifest_path)
+    actions = decide(vm_state)
     for action in actions:
         if action == Action.CREATE:
-            _action_create(project, mounts, log_path, key_path, headless=headless)
+            _action_create(project, pool, mounts, log_path, key_path, headless=headless)
         elif action == Action.UPDATE_MOUNT_AND_RESTART:
-            _action_update_mount_and_restart(project, mounts, log_path, headless=headless)
+            _action_update_mount_and_restart(project, pool, mounts, log_path, headless=headless)
         elif action == Action.START:
-            _action_start(project, mounts, log_path, headless=headless)
+            _action_start(project, pool, mounts, log_path, headless=headless)
         elif action == Action.ATTACH_MOUNT_AND_START:
-            _action_attach_mount_and_start(project, mounts, log_path, headless=headless)
+            _action_attach_mount_and_start(project, pool, mounts, log_path, headless=headless)
         elif action == Action.NOTHING:
-            _action_nothing(project)
+            _action_nothing(pool)
 
-    # Step 5: Configure SSH unconditionally. All operations are idempotent
-    # (keypair generation skips if exists, managed block upsert replaces by VM
-    # name, include is added once, authorized_keys uses grep-skip-if-present).
-    # This makes the workflow self-healing if a prior `up` was Ctrl-C'd
-    # before SSH was configured.
-    if vm.is_running(project.vm.name):
-        _configure_ssh(project, key_path)
+    if vm.is_running(pool.name):
+        _configure_ssh(project, pool, key_path)
 
-    # Step 6: Return outcome with the final manifest.
     final_manifest = manifest_read(manifest_path)
+    attachment = WorktreeAttachment(
+        pool_name=pool.name,
+        host_path=worktree_host_path.resolve(),
+        guest_path=guest_path_for_worktree(pool.name, repo_root, worktree_host_path),
+    )
     return AttachOutcome(
         actions=tuple(actions),
         manifest=tuple(final_manifest),
-        primary=primary_entry,
+        attachment=attachment,
     )
 
 
@@ -141,65 +171,65 @@ def _running_mount_names(vm_name: str) -> set[str]:
     return {line.strip() for line in result.stdout.splitlines() if line.strip()}
 
 
-def _read_state(
-    project: ProjectConfig,
-    manifest_path: Path,
-    worktree: Path,
-) -> VmState:
-    """Read current VM state. ``mount_matches`` reflects whether the running
-    guest actually has the worktree's mount loaded — queried via ``tart exec``,
-    not the on-disk manifest, because the manifest can drift ahead of the VM.
+def _read_state(pool: PoolConfig) -> VmState:
+    """Read current VM state for *pool*.
+
+    ``mount_matches`` is True iff the running guest has the umbrella share
+    (named after the pool) visible under ``/Volumes/My Shared Files``.
     """
-    name = project.vm.name
+    name = pool.name
     exists = vm.exists(name)
     running = exists and vm.is_running(name)
-    if running:
-        target_name = mount_name_for_path(project.slug, worktree)
-        mount_matches = target_name in _running_mount_names(name)
-    else:
-        mount_matches = False
+    mount_matches = pool.name in _running_mount_names(name) if running else False
     return VmState(exists=exists, running=running, mount_matches=mount_matches)
 
 
-def _resolve_git_common_dir(worktree: Path) -> Path:
-    """Return the absolute git common dir for ``worktree``.
+def _normalize_worktree_gitdirs(repo_root: Path) -> None:
+    """Rewrite ``<repo>/.worktrees/*/.git`` to use a *relative* gitdir.
 
-    In a git worktree, ``<worktree>/.git`` is a *file* pointing at the main
-    checkout's ``.git`` directory.  Tart can only mount directories, so the
-    bridge mount must target the common dir, not the per-worktree gitdir.
+    ``git worktree add`` writes ``gitdir: /abs/path/to/<repo>/.git/worktrees/<name>``
+    which is host-specific and unreadable inside the VM. A relative path
+    resolves identically on host and guest, eliminating the need for a
+    guest-side symlink bridge.
 
-    Falls back to ``<worktree>/.git`` if ``git`` is unavailable or the path is
-    not a git repository (e.g. unit tests that pass an arbitrary tmp_path).
+    Only files whose absolute target sits under ``<repo>/.git/worktrees/`` are
+    rewritten. Foreign or already-relative gitdir paths are left alone.
     """
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return worktree / ".git"
-    return (worktree / result.stdout.strip()).resolve()
-
-
-def _target_manifest(
-    project: ProjectConfig,
-    repo_root: Path,
-    worktree: Path,
-) -> list[MountEntry]:
-    """Build the target mount list: primary worktree + git-root bridge."""
-    del repo_root  # use git's own opinion of where the common dir lives
-    primary = MountEntry(
-        name=mount_name_for_path(project.slug, worktree),
-        host_path=worktree,
-    )
-    bridge = git_root_bridge_entry(project.slug, _resolve_git_common_dir(worktree))
-    return [primary, bridge]
+    worktrees_dir = repo_root / ".worktrees"
+    if not worktrees_dir.is_dir():
+        return
+    git_root = (repo_root / ".git").resolve()
+    for child in worktrees_dir.iterdir():
+        if not child.is_dir():
+            continue
+        git_file = child / ".git"
+        if not git_file.is_file():
+            continue
+        try:
+            content = git_file.read_text().strip()
+        except OSError:
+            continue
+        if not content.startswith("gitdir:"):
+            continue
+        target_str = content[len("gitdir:") :].strip()
+        target = Path(target_str)
+        if not target.is_absolute():
+            continue
+        try:
+            target_resolved = target.resolve()
+        except OSError:
+            continue
+        try:
+            target_resolved.relative_to(git_root)
+        except ValueError:
+            continue
+        rel = os.path.relpath(target_resolved, child.resolve())
+        git_file.write_text(f"gitdir: {rel}\n")
 
 
 def _action_create(
     project: ProjectConfig,
+    pool: PoolConfig,
     mounts: list[MountEntry],
     log_path: Path,
     ssh_key_path: Path,
@@ -207,14 +237,12 @@ def _action_create(
     headless: bool = True,
 ) -> None:
     """Create VM from base image, configure resources, and start it."""
-    name = project.vm.name
+    name = pool.name
     label_str = launchd.label(name)
 
-    # Truncate log to avoid confusion with stale output
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("")
 
-    # Remove any stale launchd registration for this label to avoid submit failure
     launchd.remove(label_str)
 
     step(f"cloning base image {project.vm.base_image} as VM {name} (this can take several minutes)")
@@ -229,18 +257,18 @@ def _action_create(
 
 def _action_update_mount_and_restart(
     project: ProjectConfig,
+    pool: PoolConfig,
     mounts: list[MountEntry],
     log_path: Path,
     *,
     headless: bool = True,
 ) -> None:
     """Stop the VM, update mounts, and restart."""
-    name = project.vm.name
+    name = pool.name
     label_str = launchd.label(name)
     step(f"stopping VM {name} to update mounts")
     launchd.remove(label_str)
     _wait_for_stopped(name)
-    # Also wait for launchctl to actually drop the label, to avoid submit conflict
     for _ in range(30):
         if not launchd.job_present(label_str):
             break
@@ -253,20 +281,19 @@ def _action_update_mount_and_restart(
 
 def _action_start(
     project: ProjectConfig,
+    pool: PoolConfig,
     mounts: list[MountEntry],
     log_path: Path,
     *,
     headless: bool = True,
 ) -> None:
     """Submit the VM to launchd and wait for it to be running."""
-    name = project.vm.name
+    name = pool.name
     label_str = launchd.label(name)
 
-    # Truncate log to avoid confusion with stale output
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("")
 
-    # Remove any stale launchd registration for this label to avoid submit failure
     launchd.remove(label_str)
 
     tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=headless)
@@ -277,20 +304,19 @@ def _action_start(
 
 def _action_attach_mount_and_start(
     project: ProjectConfig,
+    pool: PoolConfig,
     mounts: list[MountEntry],
     log_path: Path,
     *,
     headless: bool = True,
 ) -> None:
     """Mount is already upserted before state read; just submit and wait."""
-    name = project.vm.name
+    name = pool.name
     label_str = launchd.label(name)
 
-    # Truncate log to avoid confusion with stale output
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("")
 
-    # Remove any stale launchd registration for this label to avoid submit failure
     launchd.remove(label_str)
 
     tart_args = vm.build_run_args(name, project.vm.network, mounts, headless=headless)
@@ -299,11 +325,10 @@ def _action_attach_mount_and_start(
     _wait_for_guest_exec(name)
 
 
-def _action_nothing(project: ProjectConfig) -> None:
+def _action_nothing(pool: PoolConfig) -> None:
     """No-op — VM is already running with the correct mount."""
     get_console().print(
-        f"[dim]VM '{project.vm.name}' is already running with the correct mount. "
-        "Nothing to do.[/dim]"
+        f"[dim]VM '{pool.name}' is already running with the correct mount. Nothing to do.[/dim]"
     )
 
 
@@ -327,9 +352,9 @@ def _build_inject_command(pub: str) -> str:
     )
 
 
-def _configure_ssh(project: ProjectConfig, key_path: Path) -> None:
+def _configure_ssh(project: ProjectConfig, pool: PoolConfig, key_path: Path) -> None:
     """Configure SSH keypair, managed block, include directive, and authorized keys."""
-    name = project.vm.name
+    name = pool.name
     step(f"configuring SSH for {name}")
 
     # 1. Generate keypair (idempotent).

--- a/tools/remo-tart/tests/test_cli.py
+++ b/tools/remo-tart/tests/test_cli.py
@@ -107,6 +107,25 @@ def test_run_returns_child_exit_code(monkeypatch: pytest.MonkeyPatch, fake_repo:
 # ---------------------------------------------------------------------------
 
 
+def _attach_outcome(
+    pool_name: str = "remo-dev",
+    actions: tuple = (Action.NOTHING,),
+    host: Path | None = None,
+) -> object:
+    from remo_tart.worktree import AttachOutcome, WorktreeAttachment
+
+    host_path = host if host is not None else Path("/tmp/repo")
+    return AttachOutcome(
+        actions=actions,
+        manifest=(),
+        attachment=WorktreeAttachment(
+            pool_name=pool_name,
+            host_path=host_path,
+            guest_path=f"/Volumes/My Shared Files/{pool_name}",
+        ),
+    )
+
+
 @patch("remo_tart.cli._connect.connect_vscode")
 @patch("remo_tart.cli.worktree.ensure_attached")
 def test_up_vscode_invokes_worktree_then_connect(
@@ -114,13 +133,7 @@ def test_up_vscode_invokes_worktree_then_connect(
     connect_vscode: MagicMock,
     fake_repo: Path,
 ) -> None:
-    from remo_tart.mount import MountEntry
-
-    primary = MountEntry(name="remo-feat", host_path=fake_repo)
-    ensure.return_value = MagicMock(
-        primary=primary,
-        actions=(Action.CREATE,),
-    )
+    ensure.return_value = _attach_outcome(actions=(Action.CREATE,), host=fake_repo)
     connect_vscode.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["up", "vscode"])
@@ -136,10 +149,7 @@ def test_up_cli_mode_calls_connect_cli(
     connect_cli: MagicMock,
     fake_repo: Path,
 ) -> None:
-    from remo_tart.mount import MountEntry
-
-    primary = MountEntry(name="remo-main", host_path=fake_repo)
-    ensure.return_value = MagicMock(primary=primary, actions=(Action.NOTHING,))
+    ensure.return_value = _attach_outcome(host=fake_repo)
     connect_cli.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["up"])
@@ -154,10 +164,7 @@ def test_up_cursor_mode_calls_connect_cursor(
     connect_cursor: MagicMock,
     fake_repo: Path,
 ) -> None:
-    from remo_tart.mount import MountEntry
-
-    primary = MountEntry(name="remo-main", host_path=fake_repo)
-    ensure.return_value = MagicMock(primary=primary, actions=(Action.NOTHING,))
+    ensure.return_value = _attach_outcome(host=fake_repo)
     connect_cursor.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["up", "cursor"])
@@ -172,10 +179,7 @@ def test_up_cursor_mode_calls_connect_cursor(
 
 @patch("remo_tart.cli.worktree.ensure_attached")
 def test_use_calls_ensure_attached(ensure: MagicMock, fake_repo: Path) -> None:
-    from remo_tart.mount import MountEntry
-
-    primary = MountEntry(name="remo-main", host_path=fake_repo)
-    ensure.return_value = MagicMock(primary=primary, actions=(Action.NOTHING,))
+    ensure.return_value = _attach_outcome(host=fake_repo)
     runner = CliRunner()
     result = runner.invoke(main, ["use"])
     assert result.exit_code == 0
@@ -184,10 +188,7 @@ def test_use_calls_ensure_attached(ensure: MagicMock, fake_repo: Path) -> None:
 
 @patch("remo_tart.cli.worktree.ensure_attached")
 def test_use_with_explicit_path(ensure: MagicMock, fake_repo: Path) -> None:
-    from remo_tart.mount import MountEntry
-
-    primary = MountEntry(name="remo-wt", host_path=fake_repo)
-    ensure.return_value = MagicMock(primary=primary, actions=(Action.ATTACH_MOUNT_AND_START,))
+    ensure.return_value = _attach_outcome(actions=(Action.ATTACH_MOUNT_AND_START,), host=fake_repo)
     runner = CliRunner()
     result = runner.invoke(main, ["use", str(fake_repo)])
     assert result.exit_code == 0
@@ -235,18 +236,12 @@ def test_start_raises_when_vm_missing(vm_exists: MagicMock, fake_repo: Path) -> 
 
 @patch("remo_tart.cli._connect.connect_vscode")
 @patch("remo_tart.cli.vm.is_running")
-@patch("remo_tart.cli.mount.manifest_read")
 def test_connect_vscode_when_running(
-    manifest_read: MagicMock,
     is_running: MagicMock,
     connect_vscode: MagicMock,
     fake_repo: Path,
 ) -> None:
-    from remo_tart.mount import MountEntry
-
     is_running.return_value = True
-    primary = MountEntry(name="remo-main", host_path=fake_repo)
-    manifest_read.return_value = [primary]
     connect_vscode.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["connect", "vscode"])
@@ -265,40 +260,17 @@ def test_connect_errors_when_not_running(is_running: MagicMock, fake_repo: Path)
 
 @patch("remo_tart.cli._connect.connect_cli")
 @patch("remo_tart.cli.vm.is_running")
-@patch("remo_tart.cli.mount.manifest_read")
 def test_connect_cli_default_mode(
-    manifest_read: MagicMock,
     is_running: MagicMock,
     connect_cli: MagicMock,
     fake_repo: Path,
 ) -> None:
-    from remo_tart.mount import MountEntry
-
     is_running.return_value = True
-    primary = MountEntry(name="remo-main", host_path=fake_repo)
-    manifest_read.return_value = [primary]
     connect_cli.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["connect"])
     assert result.exit_code == 0
     connect_cli.assert_called_once()
-
-
-@patch("remo_tart.cli.vm.is_running", return_value=True)
-@patch("remo_tart.cli.mount.manifest_read", return_value=[])
-def test_connect_raises_when_manifest_is_empty(
-    manifest_read: MagicMock,
-    is_running: MagicMock,
-    fake_repo: Path,
-) -> None:
-    from remo_tart.errors import RemoTartError
-
-    runner = CliRunner()
-    result = runner.invoke(main, ["connect", "vscode"])
-    assert result.exit_code == 1
-    # RemoTartError propagates as the exception when Rich console swallows output
-    assert isinstance(result.exception, RemoTartError)
-    assert "no mounts" in str(result.exception).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -500,13 +472,106 @@ def test_bootstrap_calls_ensure_attached_and_connect_cli(
     connect_cli: MagicMock,
     fake_repo: Path,
 ) -> None:
-    from remo_tart.mount import MountEntry
-
-    primary = MountEntry(name="remo-main", host_path=fake_repo)
-    ensure.return_value = MagicMock(primary=primary, actions=(Action.CREATE,))
+    ensure.return_value = _attach_outcome(actions=(Action.CREATE,), host=fake_repo)
     connect_cli.return_value = 0
     runner = CliRunner()
     result = runner.invoke(main, ["bootstrap"])
     assert result.exit_code == 0
     ensure.assert_called_once()
     connect_cli.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# --pool flag coverage
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.cli._connect.connect_cli", return_value=0)
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_up_passes_pool_to_ensure_attached(
+    ensure: MagicMock,
+    connect: MagicMock,
+    fake_repo: Path,
+) -> None:
+    ensure.return_value = _attach_outcome(pool_name="alpha", host=fake_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["up", "--pool", "alpha"], catch_exceptions=False)
+    assert result.exit_code == 0
+    kwargs = ensure.call_args.kwargs
+    assert kwargs.get("pool_name") == "alpha"
+
+
+@patch("remo_tart.cli._connect.connect_cli", return_value=0)
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_up_default_pool_is_none(ensure: MagicMock, connect: MagicMock, fake_repo: Path) -> None:
+    ensure.return_value = _attach_outcome(host=fake_repo)
+    runner = CliRunner()
+    runner.invoke(main, ["up"], catch_exceptions=False)
+    kwargs = ensure.call_args.kwargs
+    assert kwargs.get("pool_name") is None
+
+
+@patch("remo_tart.cli.worktree.ensure_attached")
+def test_use_accepts_pool(ensure: MagicMock, fake_repo: Path) -> None:
+    ensure.return_value = _attach_outcome(pool_name="beta", host=fake_repo)
+    runner = CliRunner()
+    result = runner.invoke(main, ["use", "--pool", "beta"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert ensure.call_args.kwargs.get("pool_name") == "beta"
+
+
+@patch("remo_tart.cli.launchd.submit")
+@patch("remo_tart.cli.launchd.remove")
+@patch("remo_tart.cli.vm.exists", return_value=True)
+def test_start_uses_pool_name_for_vm(
+    exists: MagicMock, remove: MagicMock, submit: MagicMock, fake_repo: Path
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["start", "--pool", "alpha"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert exists.call_args.args == ("alpha",)
+
+
+@patch("remo_tart.cli.vm.is_running", return_value=True)
+@patch("remo_tart.cli._connect.connect_cli", return_value=0)
+def test_connect_uses_pool_name(connect: MagicMock, is_running: MagicMock, fake_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["connect", "--pool", "alpha"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert connect.call_args.args[0] == "alpha"
+
+
+@patch("remo_tart.cli._status.collect")
+@patch("remo_tart.cli._status.render_human", return_value="ok")
+def test_status_uses_pool_name(render: MagicMock, collect: MagicMock, fake_repo: Path) -> None:
+    collect.return_value = {}
+    runner = CliRunner()
+    runner.invoke(main, ["status", "--pool", "alpha"], catch_exceptions=False)
+    assert collect.call_args.args[0] == "alpha"
+
+
+@patch("remo_tart.cli._ssh.remove_include_from_user_config")
+@patch("remo_tart.cli._ssh.remove_managed_block")
+@patch("remo_tart.cli.vm.exists", return_value=False)
+@patch("remo_tart.cli.launchd.remove")
+def test_destroy_uses_pool_name(
+    ld_remove: MagicMock,
+    vm_exists: MagicMock,
+    ssh_rm_block: MagicMock,
+    ssh_rm_include: MagicMock,
+    fake_repo: Path,
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["destroy", "--pool", "alpha", "--force"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "alpha" in ld_remove.call_args.args[0]
+
+
+@patch("remo_tart.cli.mount.manifest_remove")
+def test_clean_worktree_uses_pool_name(rm: MagicMock, fake_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["clean-worktree", str(fake_repo), "--pool", "alpha"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "alpha" in str(rm.call_args.args[0])

--- a/tools/remo-tart/tests/test_connect.py
+++ b/tools/remo-tart/tests/test_connect.py
@@ -4,10 +4,20 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from remo_tart.connect import connect_cli, connect_cursor, connect_vscode
-from remo_tart.mount import MountEntry
+from remo_tart.worktree import WorktreeAttachment
 
 
-@patch("subprocess.run")
+def _attachment(
+    guest_path: str = "/Volumes/My Shared Files/remo-dev/.worktrees/foo",
+) -> WorktreeAttachment:
+    return WorktreeAttachment(
+        pool_name="remo-dev",
+        host_path=Path("/users/x/remo/.worktrees/foo"),
+        guest_path=guest_path,
+    )
+
+
+@patch("remo_tart.connect.subprocess.run")
 def test_connect_cli_runs_ssh_with_alias(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=0)
     assert connect_cli("remo-dev", "admin") == 0
@@ -15,52 +25,49 @@ def test_connect_cli_runs_ssh_with_alias(run: MagicMock) -> None:
     assert called_argv == ["ssh", "tart-remo-dev"]
 
 
-@patch("subprocess.run")
+@patch("remo_tart.connect.subprocess.run")
 def test_connect_cli_propagates_nonzero(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=130)
     assert connect_cli("remo-dev", "admin") == 130
 
 
-@patch("subprocess.run")
-def test_connect_vscode_default_reuses_window(run: MagicMock) -> None:
+@patch("remo_tart.connect.subprocess.run")
+def test_connect_vscode_builds_uri_from_attachment_guest_path(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=0)
-    mount = MountEntry("remo-feat", Path("/r"))
-    connect_vscode("remo-dev", "admin", mount)
-    (called_argv,) = run.call_args[0]
-    assert called_argv[0] == "code"
-    assert "--folder-uri" in called_argv
-    idx = called_argv.index("--folder-uri")
-    uri = called_argv[idx + 1]
-    assert uri == "vscode-remote://ssh-remote+tart-remo-dev/Volumes/My Shared Files/remo-feat"
-    assert "--reuse-window" in called_argv
-    assert "--new-window" not in called_argv
+    code = connect_vscode("remo-dev", "admin", _attachment())
+    assert code == 0
+    argv = run.call_args.args[0]
+    assert argv[0] == "code"
+    folder_uri_idx = argv.index("--folder-uri") + 1
+    assert argv[folder_uri_idx] == (
+        "vscode-remote://ssh-remote+tart-remo-dev/Volumes/My Shared Files/remo-dev/.worktrees/foo"
+    )
+    assert "--reuse-window" in argv
+    assert "--new-window" not in argv
 
 
-@patch("subprocess.run")
+@patch("remo_tart.connect.subprocess.run")
 def test_connect_vscode_new_window(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=0)
-    mount = MountEntry("remo-feat", Path("/r"))
-    connect_vscode("remo-dev", "admin", mount, new_window=True)
-    (called_argv,) = run.call_args[0]
-    assert "--new-window" in called_argv
-    assert "--reuse-window" not in called_argv
+    connect_vscode("remo-dev", "admin", _attachment(), new_window=True)
+    argv = run.call_args.args[0]
+    assert "--new-window" in argv
+    assert "--reuse-window" not in argv
 
 
-@patch("subprocess.run")
-def test_connect_cursor_uses_cursor_binary(run: MagicMock) -> None:
+@patch("remo_tart.connect.subprocess.run")
+def test_connect_cursor_builds_uri_from_attachment_guest_path(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=0)
-    mount = MountEntry("remo-feat", Path("/r"))
-    connect_cursor("remo-dev", "admin", mount)
-    (called_argv,) = run.call_args[0]
-    assert called_argv[0] == "cursor"
-    # Same URI as vscode (cursor accepts vscode-remote://)
-    idx = called_argv.index("--folder-uri")
-    uri = called_argv[idx + 1]
-    assert uri.startswith("vscode-remote://ssh-remote+tart-remo-dev/")
+    connect_cursor("remo-dev", "admin", _attachment("/Volumes/My Shared Files/remo-dev"))
+    argv = run.call_args.args[0]
+    assert argv[0] == "cursor"
+    folder_uri_idx = argv.index("--folder-uri") + 1
+    assert argv[folder_uri_idx] == (
+        "vscode-remote://ssh-remote+tart-remo-dev/Volumes/My Shared Files/remo-dev"
+    )
 
 
-@patch("subprocess.run")
+@patch("remo_tart.connect.subprocess.run")
 def test_connect_vscode_propagates_returncode(run: MagicMock) -> None:
     run.return_value = MagicMock(returncode=2)
-    mount = MountEntry("remo-feat", Path("/r"))
-    assert connect_vscode("remo-dev", "admin", mount) == 2
+    assert connect_vscode("remo-dev", "admin", _attachment()) == 2

--- a/tools/remo-tart/tests/test_mount.py
+++ b/tools/remo-tart/tests/test_mount.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 from remo_tart.mount import (
     MountEntry,
-    git_root_bridge_entry,
-    guest_bridge_script,
     manifest_prune_stale,
     manifest_read,
     manifest_remove,
@@ -118,12 +116,6 @@ def test_mount_name_for_path_slugifies(tmp_path: Path) -> None:
     assert mount_name_for_path("remo", p) == "remo-feature-branch"
 
 
-def test_git_root_bridge_entry() -> None:
-    e = git_root_bridge_entry("remo", Path("/r/.git"))
-    assert e.name == "remo-git-root"
-    assert e.host_path == Path("/r/.git")
-
-
 def test_parse_mount_spec_host_only(tmp_path: Path) -> None:
     (tmp_path / "proj").mkdir()
     e = parse_mount_spec("remo", str(tmp_path / "proj"))
@@ -135,32 +127,6 @@ def test_parse_mount_spec_with_explicit_name(tmp_path: Path) -> None:
     (tmp_path / "proj").mkdir()
     e = parse_mount_spec("remo", f"{tmp_path / 'proj'}:custom-name")
     assert e.name == "custom-name"
-
-
-def test_guest_bridge_script_contains_expected_markers() -> None:
-    script = guest_bridge_script(
-        [MountEntry("remo-feat", Path("/r"))],
-        git_root_name="remo-git-root",
-        guest_password="admin",
-    )
-    assert "#!/usr/bin/env bash" in script
-    assert "set -euo pipefail" in script
-    assert "My Shared Files/remo-git-root" in script
-    assert "remo-feat" in script
-
-
-def test_guest_bridge_script_excludes_git_root_entry() -> None:
-    script = guest_bridge_script(
-        [
-            MountEntry("remo-git-root", Path("/r/.git")),
-            MountEntry("remo-feat", Path("/r")),
-        ],
-        git_root_name="remo-git-root",
-        guest_password="admin",
-    )
-    # The git-root bridge itself must not be symlinked to its own .git subdir.
-    assert "My Shared Files/remo-git-root/.git" not in script
-    assert "My Shared Files/remo-feat/.git" in script
 
 
 def test_manifest_prune_does_not_create_missing_file(tmp_path: Path) -> None:

--- a/tools/remo-tart/tests/test_paths.py
+++ b/tools/remo-tart/tests/test_paths.py
@@ -67,3 +67,65 @@ def test_find_repo_root_raises_when_not_found(tmp_path: Path) -> None:
         find_repo_root(tmp_path)
     assert excinfo.value.hint is not None
     assert "project.toml" in excinfo.value.hint
+
+
+def test_git_worktree_root_in_main_checkout(tmp_path: Path) -> None:
+    """In the main checkout, worktree root == repo root."""
+    import subprocess as sp
+
+    from remo_tart.paths import git_worktree_root
+
+    sp.run(
+        ["git", "-C", str(tmp_path), "init", "--initial-branch=main"],
+        check=True,
+        capture_output=True,
+    )
+    sub = tmp_path / "tools" / "thing"
+    sub.mkdir(parents=True)
+    assert git_worktree_root(sub) == tmp_path.resolve()
+
+
+def test_git_worktree_root_in_linked_worktree(tmp_path: Path) -> None:
+    """Inside a `.worktrees/<name>` directory, returns that worktree root."""
+    import subprocess as sp
+
+    from remo_tart.paths import git_worktree_root
+
+    main = tmp_path / "main"
+    main.mkdir()
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "PATH": "/usr/bin:/bin",
+    }
+    sp.run(
+        ["git", "-C", str(main), "init", "--initial-branch=main"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    sp.run(
+        ["git", "-C", str(main), "commit", "--allow-empty", "-m", "i"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    wt = main / ".worktrees" / "foo"
+    sp.run(
+        ["git", "-C", str(main), "worktree", "add", str(wt)],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    inner = wt / "deep" / "dir"
+    inner.mkdir(parents=True)
+    assert git_worktree_root(inner) == wt.resolve()
+
+
+def test_git_worktree_root_falls_back_when_not_a_repo(tmp_path: Path) -> None:
+    """Outside a git repo, return the input path unchanged (resolved)."""
+    from remo_tart.paths import git_worktree_root
+
+    assert git_worktree_root(tmp_path) == tmp_path.resolve()

--- a/tools/remo-tart/tests/test_pool.py
+++ b/tools/remo-tart/tests/test_pool.py
@@ -1,0 +1,54 @@
+"""Tests for pool resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from remo_tart.config import ProjectConfig, ScriptsConfig, VmConfig
+from remo_tart.errors import RemoTartError
+from remo_tart.pool import PoolConfig, resolve_pool
+
+
+def _cfg(vm_name: str = "remo-dev") -> ProjectConfig:
+    return ProjectConfig(
+        slug="remo",
+        vm=VmConfig(
+            name=vm_name,
+            base_image="img",
+            cpu=1,
+            memory_gb=1,
+            network="shared",
+        ),
+        packs=["ios"],
+        scripts=ScriptsConfig(
+            provision=".tart/provision.sh",
+            verify_worktree=".tart/verify-worktree.sh",
+        ),
+    )
+
+
+def test_resolve_pool_default_uses_project_vm_name() -> None:
+    pool = resolve_pool(_cfg(vm_name="remo-dev"), pool_name=None)
+    assert isinstance(pool, PoolConfig)
+    assert pool.name == "remo-dev"
+
+
+def test_resolve_pool_override_uses_explicit_name() -> None:
+    pool = resolve_pool(_cfg(), pool_name="alpha")
+    assert pool.name == "alpha"
+
+
+def test_resolve_pool_rejects_empty_name() -> None:
+    with pytest.raises(RemoTartError):
+        resolve_pool(_cfg(), pool_name="")
+
+
+def test_resolve_pool_rejects_invalid_chars() -> None:
+    with pytest.raises(RemoTartError):
+        resolve_pool(_cfg(), pool_name="bad name with spaces")
+
+
+def test_pool_config_is_frozen() -> None:
+    pool = resolve_pool(_cfg(), pool_name=None)
+    with pytest.raises((AttributeError, TypeError)):
+        pool.name = "other"  # type: ignore[misc]

--- a/tools/remo-tart/tests/test_status.py
+++ b/tools/remo-tart/tests/test_status.py
@@ -157,6 +157,21 @@ def test_render_human_handles_none_and_empty_entries() -> None:
     assert "selected=null" in text
 
 
+def test_status_collect_with_umbrella_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest_write(mount_manifest_path("alpha"), [MountEntry("alpha", repo)])
+
+    with patch("remo_tart.status.vm.exists", return_value=False):
+        data = collect("alpha", repo, repo)
+    assert data["mounts"]["count"] == 1
+    assert data["mounts"]["entries"][0]["name"] == "alpha"
+    assert data["mounts"]["selected"] == "alpha"
+
+
 def test_render_json_is_valid_json() -> None:
     data = {
         "vm": {"name": "x", "exists": True, "running": True, "ip": "1.2.3.4"},

--- a/tools/remo-tart/tests/test_status.py
+++ b/tools/remo-tart/tests/test_status.py
@@ -165,7 +165,10 @@ def test_status_collect_with_umbrella_manifest(
     repo.mkdir()
     manifest_write(mount_manifest_path("alpha"), [MountEntry("alpha", repo)])
 
-    with patch("remo_tart.status.vm.exists", return_value=False):
+    with (
+        patch("remo_tart.status.vm.exists", return_value=False),
+        patch("remo_tart.status.launchd.job_present", return_value=False),
+    ):
         data = collect("alpha", repo, repo)
     assert data["mounts"]["count"] == 1
     assert data["mounts"]["entries"][0]["name"] == "alpha"

--- a/tools/remo-tart/tests/test_worktree.py
+++ b/tools/remo-tart/tests/test_worktree.py
@@ -119,8 +119,8 @@ def test_stopped_with_matching_mount_triggers_start(
     config_ssh.assert_called_once()
 
 
-def test_ensure_attached_upserts_primary_and_git_root(fake_home: Path, fake_repo: Path) -> None:
-    """The manifest must contain both the worktree entry and the git-root bridge."""
+def test_ensure_attached_writes_single_umbrella_entry(fake_home: Path, fake_repo: Path) -> None:
+    """Manifest contains exactly one entry: pool.name → repo_root."""
     from remo_tart.paths import mount_manifest_path
 
     with (
@@ -132,67 +132,63 @@ def test_ensure_attached_upserts_primary_and_git_root(fake_home: Path, fake_repo
         read.return_value = VmState(exists=True, running=True, mount_matches=True)
         ensure_attached(fake_repo, _cfg(), fake_repo)
 
-    entries = list(_read_manifest(mount_manifest_path("remo-dev")))
-    names = {e.name for e in entries}
-    assert "remo-git-root" in names
-    # primary mount name is derived from worktree basename
-    assert any(n.startswith("remo") and n != "remo-git-root" for n in names)
+    entries = _read_manifest(mount_manifest_path("remo-dev"))
+    assert len(entries) == 1
+    assert entries[0].name == "remo-dev"
+    assert entries[0].host_path == fake_repo.resolve()
+
+
+def test_ensure_attached_drops_legacy_manifest_entries(fake_home: Path, fake_repo: Path) -> None:
+    """Pre-umbrella per-worktree + bridge entries are dropped on attach."""
+    from remo_tart.mount import MountEntry, manifest_write
+    from remo_tart.paths import mount_manifest_path
+
+    mp = mount_manifest_path("remo-dev")
+    manifest_write(
+        mp,
+        [
+            MountEntry("remo", Path("/old/main")),
+            MountEntry("remo-feature-x", Path("/old/wt")),
+            MountEntry("remo-git-root", Path("/old/.git")),
+        ],
+    )
+
+    with (
+        patch("remo_tart.worktree._read_state") as read,
+        patch("remo_tart.worktree._action_nothing"),
+        patch("remo_tart.worktree._configure_ssh"),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
+    ):
+        read.return_value = VmState(exists=True, running=True, mount_matches=True)
+        ensure_attached(fake_repo, _cfg(), fake_repo)
+
+    entries = _read_manifest(mount_manifest_path("remo-dev"))
+    assert [e.name for e in entries] == ["remo-dev"]
+
+
+def test_ensure_attached_uses_pool_name_when_provided(fake_home: Path, fake_repo: Path) -> None:
+    """`--pool alpha` writes manifest at <alpha>.mounts and uses VM name 'alpha'."""
+    from remo_tart.paths import mount_manifest_path
+
+    with (
+        patch("remo_tart.worktree._read_state") as read,
+        patch("remo_tart.worktree._action_nothing"),
+        patch("remo_tart.worktree._configure_ssh"),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
+    ):
+        read.return_value = VmState(exists=True, running=True, mount_matches=True)
+        outcome = ensure_attached(fake_repo, _cfg(), fake_repo, pool_name="alpha")
+
+    entries = _read_manifest(mount_manifest_path("alpha"))
+    assert [e.name for e in entries] == ["alpha"]
+    assert outcome.attachment.pool_name == "alpha"
+    assert outcome.attachment.guest_path == "/Volumes/My Shared Files/alpha"
 
 
 def _read_manifest(path: Path) -> list:
     from remo_tart.mount import manifest_read
 
     return manifest_read(path)
-
-
-def test_resolve_git_common_dir_uses_git_when_in_a_worktree(tmp_path: Path) -> None:
-    """In a real git worktree, ``<worktree>/.git`` is a *file* pointing at the
-    main checkout's ``.git`` directory.  ``_resolve_git_common_dir`` must
-    return the directory, not the file, so Tart can mount it.
-    """
-    import subprocess as sp
-
-    from remo_tart.worktree import _resolve_git_common_dir
-
-    main = tmp_path / "main"
-    main.mkdir()
-    git_env = {
-        "GIT_AUTHOR_NAME": "t",
-        "GIT_AUTHOR_EMAIL": "t@t",
-        "GIT_COMMITTER_NAME": "t",
-        "GIT_COMMITTER_EMAIL": "t@t",
-        "PATH": "/usr/bin:/bin",
-    }
-    sp.run(
-        ["git", "-C", str(main), "init", "--initial-branch=main"],
-        check=True,
-        capture_output=True,
-        env=git_env,
-    )
-    sp.run(
-        ["git", "-C", str(main), "commit", "--allow-empty", "-m", "init"],
-        check=True,
-        capture_output=True,
-        env=git_env,
-    )
-    worktree_path = tmp_path / "wt"
-    sp.run(
-        ["git", "-C", str(main), "worktree", "add", str(worktree_path)],
-        check=True,
-        capture_output=True,
-        env=git_env,
-    )
-
-    assert (worktree_path / ".git").is_file()  # worktree gitdir is a FILE
-    common = _resolve_git_common_dir(worktree_path)
-    assert common.is_dir()
-    assert common == (main / ".git").resolve()
-
-
-def test_resolve_git_common_dir_falls_back_when_not_a_git_repo(tmp_path: Path) -> None:
-    from remo_tart.worktree import _resolve_git_common_dir
-
-    assert _resolve_git_common_dir(tmp_path) == tmp_path / ".git"
 
 
 # ---------------------------------------------------------------------------
@@ -217,8 +213,11 @@ def test_action_create_cleans_stale_launchd_and_truncates_log(
     log.parent.mkdir(parents=True, exist_ok=True)
     log.write_text("stale content\n")
 
+    from remo_tart.pool import resolve_pool
+
+    pool = resolve_pool(_cfg(), pool_name=None)
     with patch("remo_tart.worktree.vm.create"), patch("remo_tart.worktree.vm.set_resources"):
-        _action_create(_cfg(), [], log, Path("/tmp/k"))
+        _action_create(_cfg(), pool, [], log, Path("/tmp/k"))
 
     # stale log truncated
     assert log.read_text() == ""
@@ -244,7 +243,10 @@ def test_action_start_cleans_stale_launchd_and_truncates_log(
     log.parent.mkdir(parents=True, exist_ok=True)
     log.write_text("stale content\n")
 
-    _action_start(_cfg(), [], log)
+    from remo_tart.pool import resolve_pool
+
+    pool = resolve_pool(_cfg(), pool_name=None)
+    _action_start(_cfg(), pool, [], log)
 
     # stale log truncated
     assert log.read_text() == ""
@@ -287,11 +289,13 @@ def test_configure_ssh_raises_when_guest_injection_fails(
     fake_home: Path,
 ) -> None:
     from remo_tart.errors import RemoTartError
+    from remo_tart.pool import resolve_pool
     from remo_tart.worktree import _configure_ssh
 
+    pool = resolve_pool(_cfg(), pool_name=None)
     exec_capture.return_value = MagicMock(returncode=1, stderr="boom", stdout="")
     with pytest.raises(RemoTartError) as excinfo:
-        _configure_ssh(_cfg(), Path("/tmp/k"))
+        _configure_ssh(_cfg(), pool, Path("/tmp/k"))
     assert excinfo.value.hint is not None
 
 
@@ -350,9 +354,11 @@ def test_update_and_restart_removes_before_submit(
     job_present: MagicMock,
     fake_home: Path,
 ) -> None:
+    from remo_tart.pool import resolve_pool
     from remo_tart.worktree import _action_update_mount_and_restart
 
-    _action_update_mount_and_restart(_cfg(), [], Path("/tmp/log"))
+    pool = resolve_pool(_cfg(), pool_name=None)
+    _action_update_mount_and_restart(_cfg(), pool, [], Path("/tmp/log"))
 
     # remove was called before submit
     assert remove.call_count == 1
@@ -369,7 +375,7 @@ def test_update_and_restart_removes_before_submit(
 # ---------------------------------------------------------------------------
 
 
-def test_attach_outcome_has_primary_and_immutable_fields(fake_home: Path, fake_repo: Path) -> None:
+def test_attach_outcome_carries_attachment(fake_home: Path, fake_repo: Path) -> None:
     with (
         patch("remo_tart.worktree._read_state") as read,
         patch("remo_tart.worktree._action_nothing"),
@@ -381,7 +387,138 @@ def test_attach_outcome_has_primary_and_immutable_fields(fake_home: Path, fake_r
 
     assert isinstance(outcome.actions, tuple)
     assert isinstance(outcome.manifest, tuple)
-    assert outcome.primary.host_path == fake_repo.resolve()
-    # Frozen dataclass forbids rebinding
+    assert outcome.attachment.pool_name == "remo-dev"
+    assert outcome.attachment.host_path == fake_repo.resolve()
+    assert outcome.attachment.guest_path == "/Volumes/My Shared Files/remo-dev"
     with pytest.raises((AttributeError, TypeError)):
-        outcome.primary = outcome.primary  # type: ignore[misc]
+        outcome.attachment = outcome.attachment  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# WorktreeAttachment + guest_path_for_worktree
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_attachment_guest_path_main_checkout() -> None:
+    """Main checkout (worktree == repo root) has guest_path = umbrella root."""
+    from remo_tart.worktree import guest_path_for_worktree
+
+    repo = Path("/users/x/remo")
+    assert guest_path_for_worktree("remo-dev", repo, repo) == "/Volumes/My Shared Files/remo-dev"
+
+
+def test_worktree_attachment_guest_path_linked_worktree() -> None:
+    """A worktree under .worktrees/foo resolves to <umbrella>/.worktrees/foo."""
+    from remo_tart.worktree import guest_path_for_worktree
+
+    repo = Path("/users/x/remo")
+    wt = repo / ".worktrees" / "foo"
+    assert (
+        guest_path_for_worktree("remo-dev", repo, wt)
+        == "/Volumes/My Shared Files/remo-dev/.worktrees/foo"
+    )
+
+
+def test_worktree_attachment_rejects_path_outside_repo() -> None:
+    """Worktrees outside the repo root are not yet supported in pools."""
+    from remo_tart.errors import RemoTartError
+    from remo_tart.worktree import guest_path_for_worktree
+
+    with pytest.raises(RemoTartError):
+        guest_path_for_worktree("remo-dev", Path("/users/x/remo"), Path("/elsewhere"))
+
+
+# ---------------------------------------------------------------------------
+# _normalize_worktree_gitdirs
+# ---------------------------------------------------------------------------
+
+
+def _init_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a main checkout with one linked worktree under .worktrees/foo."""
+    import subprocess as sp
+
+    main = tmp_path / "main"
+    main.mkdir()
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "PATH": "/usr/bin:/bin",
+    }
+    sp.run(
+        ["git", "-C", str(main), "init", "--initial-branch=main"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    sp.run(
+        ["git", "-C", str(main), "commit", "--allow-empty", "-m", "i"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    wt = main / ".worktrees" / "foo"
+    sp.run(
+        ["git", "-C", str(main), "worktree", "add", str(wt)],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    return main, wt
+
+
+def test_normalize_worktree_gitdirs_rewrites_absolute_to_relative(tmp_path: Path) -> None:
+    """An absolute gitdir under repo .git is rewritten to a relative path."""
+    from remo_tart.worktree import _normalize_worktree_gitdirs
+
+    main, wt = _init_worktree(tmp_path)
+    git_file = wt / ".git"
+    original = git_file.read_text()
+    assert original.startswith("gitdir: ")
+    assert "/" in original  # absolute, host-specific
+
+    _normalize_worktree_gitdirs(main)
+
+    rewritten = git_file.read_text().strip()
+    assert rewritten.startswith("gitdir: ")
+    rel = rewritten[len("gitdir: ") :]
+    assert not rel.startswith("/")
+    resolved = (wt / rel).resolve()
+    assert resolved == (main / ".git" / "worktrees" / "foo").resolve()
+
+
+def test_normalize_worktree_gitdirs_is_idempotent(tmp_path: Path) -> None:
+    """Running twice is a no-op once paths are already relative."""
+    from remo_tart.worktree import _normalize_worktree_gitdirs
+
+    main, wt = _init_worktree(tmp_path)
+    _normalize_worktree_gitdirs(main)
+    first = (wt / ".git").read_text()
+    _normalize_worktree_gitdirs(main)
+    second = (wt / ".git").read_text()
+    assert first == second
+
+
+def test_normalize_worktree_gitdirs_skips_when_no_worktrees(tmp_path: Path) -> None:
+    """Repos without .worktrees/ do nothing and don't error."""
+    from remo_tart.worktree import _normalize_worktree_gitdirs
+
+    (tmp_path / ".git").mkdir()
+    _normalize_worktree_gitdirs(tmp_path)
+
+
+def test_normalize_worktree_gitdirs_leaves_external_gitdir_alone(tmp_path: Path) -> None:
+    """Worktrees pointing outside repo .git/worktrees/ are not rewritten."""
+    from remo_tart.worktree import _normalize_worktree_gitdirs
+
+    repo = tmp_path / "main"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    wt = repo / ".worktrees" / "external"
+    wt.mkdir(parents=True)
+    foreign = "gitdir: /some/other/place\n"
+    (wt / ".git").write_text(foreign)
+
+    _normalize_worktree_gitdirs(repo)
+    assert (wt / ".git").read_text() == foreign


### PR DESCRIPTION
## Summary
- Mount the project root once as `<pool_name>` instead of one share per worktree. Subsequent `up` from any sibling worktree collapses to `NOTHING` because the umbrella already covers it.
- Introduce `PoolConfig` + `--pool` flag. Default pool name = `project.vm.name`, so single-VM behavior is unchanged. `--pool <name>` opts a worktree into a distinct VM for parallel/isolated work.
- Worktree `.git` pointers (host-absolute as written by `git worktree add`) are normalised to repo-relative paths during attach, so the same `.git` file resolves correctly on host and inside the VM. This removes the need for the per-worktree guest symlink bridge.
- `WorktreeAttachment` carries `host_path` + `guest_path` so editors open the specific worktree under the umbrella, not the umbrella root.

## Migration
- First `up` after upgrade: pool VM is running with legacy per-worktree mounts; the new code computes a single umbrella entry, `mount_matches=False`, triggers `UPDATE_MOUNT_AND_RESTART` once.
- Subsequent `up` from any worktree → `NOTHING`.

## Test plan
- [x] \`uv run pytest tools/remo-tart -v\` — 180/180 passing
- [ ] First \`up\` on the upgraded VM: triggers UPDATE_MOUNT_AND_RESTART once
- [ ] Second \`up\` from a different worktree: actions = NOTHING
- [ ] \`up --pool alpha\` creates a second VM identity without disturbing the default pool
- [ ] VS Code / Cursor open the actual worktree path inside the VM (not the umbrella root)
- [ ] \`git status\` works inside a worktree from inside the VM (validates relative gitdir rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)