### PR TITLE
fix(tart): restore pack bash helpers via .tart/packs/_lib.sh

### DIFF
--- a/.tart/packs/_lib.sh
+++ b/.tart/packs/_lib.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Helpers shared by every pack. Sourced by remo_tart.provision.build_guest_script
+# before any individual pack is sourced, so pack functions can rely on these
+# being defined.
+
+retry_command() {
+    local description max_attempts delay attempt status
+    description="$1"
+    shift
+
+    max_attempts="${REMO_TART_RETRY_ATTEMPTS:-3}"
+    delay="${REMO_TART_RETRY_DELAY_SECONDS:-2}"
+    attempt=1
+
+    case "${max_attempts}" in
+        ''|*[!0-9]*)
+            echo "REMO_TART_RETRY_ATTEMPTS must be a positive integer" >&2
+            return 1
+            ;;
+    esac
+    if [[ "${max_attempts}" -lt 1 ]]; then
+        echo "REMO_TART_RETRY_ATTEMPTS must be at least 1" >&2
+        return 1
+    fi
+
+    while true; do
+        if "$@"; then
+            return 0
+        else
+            status=$?
+        fi
+        if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+            echo "${description} failed after ${attempt}/${max_attempts} attempts" >&2
+            return "${status}"
+        fi
+
+        echo "${description} failed on attempt ${attempt}/${max_attempts}; retrying in ${delay}s" >&2
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+    done
+}
+
+ensure_xcode() {
+    if ! command -v xcodebuild >/dev/null 2>&1; then
+        echo "xcodebuild not found in guest; verify the base image ships Xcode" >&2
+        return 1
+    fi
+    xcodebuild -version >/dev/null
+}
+
+ensure_node_and_npm() {
+    if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! command -v brew >/dev/null 2>&1; then
+        echo "node/npm missing and Homebrew is unavailable in the guest" >&2
+        return 1
+    fi
+
+    retry_command "install node via Homebrew" brew install node
+}
+
+ensure_codex() {
+    if command -v codex >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "npm not found; cannot install Codex CLI" >&2
+        return 1
+    fi
+
+    retry_command "install Codex CLI" npm install -g @openai/codex
+}
+
+# Emit shell `export` statements for env vars every worktree session needs.
+# Each pack may define `tart_pack_<name>_worktree_env_exports` to contribute
+# pack-specific exports (e.g. ios DerivedData, node npm cache); we discover
+# them via `declare -F` rather than re-reading project config.
+remo_tart_worktree_env_exports() {
+    local worktree_root tmpdir
+    worktree_root="$1"
+    tmpdir="${worktree_root}/.tart/tmp"
+    mkdir -p "${tmpdir}"
+
+    printf 'export REMO_TART_WORKTREE_ROOT=%q\n' "${worktree_root}"
+    printf 'export TMPDIR=%q\n' "${tmpdir}"
+
+    local export_func
+    while IFS= read -r export_func; do
+        [[ -n "${export_func}" ]] || continue
+        "${export_func}" "${worktree_root}"
+    done < <(declare -F | awk '/^declare -f tart_pack_.*_worktree_env_exports$/ {print $3}')
+}

--- a/.tart/packs/agents.sh
+++ b/.tart/packs/agents.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Provision Claude Code CLI and XcodeBuildMCP CLI inside the guest.
-# Relies on helpers sourced by scripts/tart/provision-dev-vm.sh:
+# Relies on helpers from .tart/packs/_lib.sh:
 #   - ensure_node_and_npm
 #   - retry_command
 

--- a/.tart/packs/shell.sh
+++ b/.tart/packs/shell.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Provision zsh + oh-my-zsh + plugins for the guest `admin` user.
-# Relies on helpers sourced by scripts/tart/provision-dev-vm.sh:
+# Relies on helpers from .tart/packs/_lib.sh:
 #   - retry_command
 #   - remo_tart_worktree_env_exports
 

--- a/tools/remo-tart/src/remo_tart/provision.py
+++ b/tools/remo-tart/src/remo_tart/provision.py
@@ -54,6 +54,12 @@ def build_guest_script(
         "",
     ]
 
+    # Source the shared helper library first; packs depend on its functions
+    # (retry_command, ensure_xcode, ensure_node_and_npm, ensure_codex,
+    # remo_tart_worktree_env_exports).
+    lines.append(f"source {_always_quote(f'{packs_dir_guest}/_lib.sh')}")
+    lines.append("")
+
     # Source each enabled pack
     for pack in project.packs:
         pack_path = f"{packs_dir_guest}/{pack}.sh"

--- a/tools/remo-tart/tests/test_provision.py
+++ b/tools/remo-tart/tests/test_provision.py
@@ -48,6 +48,17 @@ def test_script_sources_each_enabled_pack() -> None:
     assert 'source "/P/node.sh"' in script or "source '/P/node.sh'" in script
 
 
+def test_script_sources_lib_before_any_pack() -> None:
+    script = build_guest_script(
+        _cfg(["ios", "rust"]), _mounts(), packs_dir_guest="/P", verify=False
+    )
+    lib_idx = script.index("_lib.sh")
+    ios_idx = script.index("ios.sh")
+    rust_idx = script.index("rust.sh")
+    assert lib_idx < ios_idx
+    assert lib_idx < rust_idx
+
+
 def test_script_calls_ensure_function_for_each_pack() -> None:
     script = build_guest_script(_cfg(["ios", "rust"]), _mounts(), packs_dir_guest="/P", verify=True)
     assert "tart_pack_ios_ensure" in script
@@ -87,8 +98,9 @@ def test_script_skips_git_root_bridge_for_primary_mount_selection() -> None:
 
 def test_script_with_empty_packs_list() -> None:
     script = build_guest_script(_cfg(packs=[]), _mounts(), packs_dir_guest="/P", verify=False)
-    # No `source` lines for packs, but the project provision script still runs
-    assert "source" not in script
+    # Helper library is always sourced; no per-pack source lines beyond _lib.sh.
+    assert script.count("source ") == 1
+    assert "_lib.sh" in script
     assert "provision.sh" in script
 
 


### PR DESCRIPTION
## Summary
- `.tart/packs/{shell,ios,node,agents}.sh` referenced helpers (`retry_command`, `ensure_xcode`, `ensure_node_and_npm`, `ensure_codex`, `remo_tart_worktree_env_exports`) that lived in `scripts/tart/common.sh` + `provision-dev-vm.sh` — both deleted in `a6153b0`. Under `set -euo pipefail` the first guest-side `tart_pack_*_ensure` call would die with `command not found`.
- Re-home the five helpers in a new `.tart/packs/_lib.sh` and have `build_guest_script` source it before any pack, so pack functions can rely on them being defined.
- The new `remo_tart_worktree_env_exports` discovers per-pack contributors via `declare -F` rather than re-parsing project config — simpler than the legacy version.
- Misleading comments in `shell.sh` / `agents.sh` pointing at the deleted `provision-dev-vm.sh` updated to point at `_lib.sh`.

## Test plan
- [x] `pytest` (161 passed)
- [x] `ruff check` clean; `cargo fmt --check` + `cargo clippy` clean (pre-commit)
- [x] `bash -n .tart/packs/_lib.sh` syntax OK
- [x] Smoke: source `_lib.sh` + `ios.sh` + `node.sh` on host, call `remo_tart_worktree_env_exports /tmp/x` — emits `REMO_TART_WORKTREE_ROOT`, `TMPDIR`, ios `REMO_TART_DERIVED_DATA`, node `npm_config_cache`
- [ ] Manual: run `remo-tart up` in a fresh VM end-to-end (host-side smoke can't cover guest-only paths like `brew install node`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)