### PR TITLE
fix(remo-tart): pass worktree_root to every pack ensure call

### DIFF
--- a/tools/remo-tart/src/remo_tart/provision.py
+++ b/tools/remo-tart/src/remo_tart/provision.py
@@ -68,9 +68,12 @@ def build_guest_script(
     if project.packs:
         lines.append("")
 
-    # Call the ensure function for each enabled pack
+    # Call the ensure function for each enabled pack. Pass the worktree root
+    # (the primary mount's guest path) so pack functions can locate the
+    # in-tree .tart/<pack-cache>/ directories. Packs that don't need it
+    # simply ignore extra args.
     for pack in project.packs:
-        lines.append(f"tart_pack_{pack}_ensure")
+        lines.append(f"tart_pack_{pack}_ensure {shlex.quote(primary_guest_path)}")
 
     if project.packs:
         lines.append("")

--- a/tools/remo-tart/tests/test_provision.py
+++ b/tools/remo-tart/tests/test_provision.py
@@ -65,6 +65,17 @@ def test_script_calls_ensure_function_for_each_pack() -> None:
     assert "tart_pack_rust_ensure" in script
 
 
+def test_script_passes_worktree_root_to_each_ensure() -> None:
+    """Regression: shell pack reads $1 under set -u; missing arg aborts provision."""
+    script = build_guest_script(
+        _cfg(["shell", "ios", "rust"]), _mounts(), packs_dir_guest="/P", verify=False
+    )
+    primary_guest_path = "/Volumes/My Shared Files/remo-feat"
+    assert f"tart_pack_shell_ensure '{primary_guest_path}'" in script
+    assert f"tart_pack_ios_ensure '{primary_guest_path}'" in script
+    assert f"tart_pack_rust_ensure '{primary_guest_path}'" in script
+
+
 def test_script_uses_primary_mount_for_project_scripts() -> None:
     script = build_guest_script(_cfg(), _mounts(), packs_dir_guest="/P", verify=True)
     # primary mount is remo-feat (first non-git-root)


### PR DESCRIPTION
## Summary
- `shell.sh`'s `tart_pack_shell_ensure` opens with `worktree_root=\"\$1\"`. Under the provisioner's `set -euo pipefail`, calling it without an argument dies on `\$1: unbound variable`.
- Because `shell` is the first enabled pack in a typical config, that abort takes the **entire** guest script with it — `ios`, `node`, `agents` never run, so oh-my-zsh, Claude Code CLI, and xcodebuildmcp silently never install.
- Fix: have `build_guest_script` pass the primary mount's guest path to every `tart_pack_<name>_ensure` call. Packs that don't read `\$1` (ios/node/agents/rust/go/python) ignore extra args harmlessly.

## Reproduction (host)
```
$ bash -c 'set -euo pipefail; foo() { local x; x=\"\$1\"; }; foo'
bash: line 1: \$1: unbound variable
```

## Test plan
- [x] `pytest` (182 passed) — including new regression `test_script_passes_worktree_root_to_each_ensure`
- [x] `ruff check`, `cargo fmt --check`, `cargo clippy` clean (pre-commit)
- [x] Host smoke: source `_lib.sh` + `shell.sh`, stub installers, call `tart_pack_shell_ensure /tmp/x` under `set -euo pipefail` — completes cleanly
- [ ] Manual: run `remo-tart up` after merge in a fresh VM and confirm omz / Claude Code / xcodebuildmcp are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)