### PR TITLE
fix(remo-tart): make ensure_attached actually deliver a working VM

### DIFF
--- a/tools/remo-tart/src/remo_tart/launchd.py
+++ b/tools/remo-tart/src/remo_tart/launchd.py
@@ -60,6 +60,44 @@ def job_present(label_str: str) -> bool:
     return result.returncode == 0
 
 
+def running_tart_argv(label_str: str) -> list[str] | None:
+    """Return the argv of the ``tart`` invocation managed by *label_str*.
+
+    Parses the ``arguments = { ... }`` block from ``launchctl print``. The
+    block always contains an ``exec tart …`` shell command line because we
+    submit jobs via ``/bin/zsh -lc 'exec tart … > log 2>&1'`` (see
+    :func:`build_submit_argv`). Returns ``None`` if the job is not active or
+    the command line cannot be located.
+
+    The returned list starts with ``"tart"`` (e.g. ``["tart", "run",
+    "<vm>", "--dir", "<name>:<path>", ...]``); trailing shell redirection
+    tokens (``> /log 2>&1``) are stripped.
+    """
+    target = f"gui/{_gui_uid()}/{label_str}"
+    result = subprocess.run(
+        ["launchctl", "print", target],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    for raw in result.stdout.splitlines():
+        line = raw.strip()
+        if not line.startswith("exec tart "):
+            continue
+        try:
+            tokens = shlex.split(line[len("exec ") :])
+        except ValueError:
+            return None
+        # Strip trailing shell redirections (`> /path/log 2>&1`).
+        for sentinel in ("2>&1", ">"):
+            if sentinel in tokens:
+                tokens = tokens[: tokens.index(sentinel)]
+        return tokens
+    return None
+
+
 def cleanup_stale(label_str: str, vm_running: bool) -> bool:
     """If a launchd job is registered but the VM isn't actually running, remove it.
 

--- a/tools/remo-tart/src/remo_tart/paths.py
+++ b/tools/remo-tart/src/remo_tart/paths.py
@@ -37,11 +37,48 @@ def user_ssh_config_path() -> Path:
 
 
 def find_repo_root(start: Path | None = None) -> Path:
-    """Walk upward from ``start`` (default cwd) until ``.tart/project.toml`` is found.
+    """Resolve the Tart-managed project root containing ``.tart/project.toml``.
 
-    Raises ``RemoTartError`` if not found.
+    Strategy:
+
+    1. If *start* (or cwd) is inside a git repo, ask git for ``--git-common-dir``
+       and use its parent as the candidate. ``--git-common-dir`` returns the
+       *main* repo's ``.git`` even when invoked from a linked worktree, so this
+       step skips past any per-worktree stray ``.tart/`` shadows. If the
+       resolved candidate has ``.tart/project.toml``, return it.
+    2. Otherwise (or as a fallback for non-git directories), walk upward from
+       *start* and return the first ancestor with ``.tart/project.toml``.
+
+    Raises :class:`RemoTartError` if no candidate yields a project file.
     """
+    import subprocess
+
     current = (start or Path.cwd()).resolve()
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(current),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        common_dir = Path(result.stdout.strip()).resolve()
+        # `--git-common-dir` points at the main repo's .git directory; its
+        # parent is the main checkout root. For linked worktrees this differs
+        # from `--show-toplevel`, which is exactly what we want here.
+        candidate = common_dir.parent
+        if (candidate / ".tart" / "project.toml").is_file():
+            return candidate
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
     for candidate in [current, *current.parents]:
         if (candidate / ".tart" / "project.toml").is_file():
             return candidate

--- a/tools/remo-tart/src/remo_tart/paths.py
+++ b/tools/remo-tart/src/remo_tart/paths.py
@@ -24,6 +24,20 @@ def vm_log_path(vm_name: str) -> Path:
     return _config_root() / f"{vm_name}.log"
 
 
+def provisioned_hash_path(vm_name: str) -> Path:
+    """State file recording the config hash that was last successfully
+    provisioned into this VM. Compared on every ``up`` to detect drift
+    between what's installed in the VM and what the on-disk config now
+    asks for; mismatch forces a re-run of ``provision.run_provision``
+    even when the VM-state machine would otherwise return ``NOTHING``.
+
+    File contents: a single line with the hex SHA-256 (no trailing
+    newline). Missing file = "never provisioned" (also forces
+    provision).
+    """
+    return _config_root() / f"{vm_name}.provisioned-hash"
+
+
 def ssh_include_path() -> Path:
     return _config_root() / "ssh_config"
 

--- a/tools/remo-tart/src/remo_tart/provision.py
+++ b/tools/remo-tart/src/remo_tart/provision.py
@@ -3,11 +3,19 @@
 Builds a bash script that runs inside the tart VM to source each enabled
 pack, call its ``tart_pack_<name>_ensure`` function, run the project-level
 provision hook, and optionally run the verify-worktree hook.
+
+Also exposes :func:`config_hash`, which deterministically hashes every
+input that affects what provision installs (enabled packs, pack contents,
+``_lib.sh``, ``provision.sh``). Used by the orchestrator to detect
+config drift between attaches and force a reprovision when the on-disk
+config diverges from what was last provisioned into the VM.
 """
 
 from __future__ import annotations
 
+import hashlib
 import shlex
+from pathlib import Path
 
 from remo_tart import vm
 from remo_tart.config import ProjectConfig
@@ -116,3 +124,70 @@ def _packs_dir_guest(mounts: list[MountEntry]) -> str:
             return f"{_SHARED_ROOT}/{entry.name}/.tart/packs"
     primary = _primary_mount(mounts)
     return f"{_SHARED_ROOT}/{primary.name}/.tart/packs"
+
+
+def config_hash(project: ProjectConfig, repo_root: Path) -> str:
+    """Hex SHA-256 of every input that affects what provision installs.
+
+    Inputs (mixed in deterministic order):
+
+    * ``project.packs`` enabled list (sorted) — adding/removing a pack
+      changes the hash even if no file content changed.
+    * ``.tart/packs/_lib.sh`` content — shared helpers; one byte changed
+      here can affect every pack's behaviour.
+    * Each enabled pack's ``.tart/packs/<name>.sh`` content.
+    * ``project.scripts.provision`` content (resolved against
+      *repo_root*) — picks up ``provision.sh`` edits like adding a
+      ``claude plugin install`` line.
+
+    Deliberately *not* hashed:
+
+    * VM resources (``cpu``, ``memory_gb``, ``base_image``,
+      ``network``) — these don't influence what's installed; changing
+      them needs a VM restart, not a re-provision. ``doctor`` is the
+      right place to surface those discrepancies.
+    * ``project.scripts.verify_worktree`` — verify is a smoke test, not
+      a state-mutating step; rerunning provision over verify changes
+      doesn't help.
+    * Files outside ``packs/`` and the provision script — provision can
+      only see what packs install.
+
+    Returns the hex digest. Missing input files contribute the literal
+    string ``"<missing>"`` so renaming a pack file is detected even if
+    the rename happens to leave content identical.
+    """
+    h = hashlib.sha256()
+
+    enabled = sorted(project.packs)
+    h.update(b"enabled\0")
+    for name in enabled:
+        h.update(name.encode("utf-8"))
+        h.update(b"\0")
+    h.update(b"\1")
+
+    packs_dir = repo_root / ".tart" / "packs"
+    h.update(b"_lib.sh\0")
+    h.update(_read_for_hash(packs_dir / "_lib.sh"))
+    h.update(b"\1")
+
+    for name in enabled:
+        h.update(f"pack:{name}\0".encode())
+        h.update(_read_for_hash(packs_dir / f"{name}.sh"))
+        h.update(b"\1")
+
+    h.update(b"provision\0")
+    h.update(_read_for_hash(repo_root / project.scripts.provision))
+    h.update(b"\1")
+
+    return h.hexdigest()
+
+
+def _read_for_hash(path: Path) -> bytes:
+    """Read *path*'s bytes, or return a sentinel marker if it doesn't
+    exist. Missing files contribute *something* to the hash so that
+    deleting a referenced file flips the digest.
+    """
+    try:
+        return path.read_bytes()
+    except (FileNotFoundError, IsADirectoryError, PermissionError):
+        return b"<missing>"

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -25,6 +25,7 @@ from remo_tart.mount import (
 )
 from remo_tart.paths import (
     mount_manifest_path,
+    provisioned_hash_path,
     ssh_include_path,
     ssh_key_path,
     user_ssh_config_path,
@@ -139,14 +140,25 @@ def ensure_attached(
 
     if vm.is_running(pool.name):
         _configure_ssh(project, pool, key_path)
-        if any(a != Action.NOTHING for a in actions):
-            step("running packs ensure + project provision hook")
+
+        current_hash = provision.config_hash(project, repo_root)
+        last_hash = _read_provisioned_hash(pool.name)
+        config_drifted = current_hash != last_hash
+        vm_changed = any(a != Action.NOTHING for a in actions)
+
+        if vm_changed or config_drifted:
+            if config_drifted and not vm_changed:
+                short_old = last_hash[:8] if last_hash else "none"
+                step(f"config drift detected ({short_old} → {current_hash[:8]}); reprovisioning")
+            else:
+                step("running packs ensure + project provision hook")
             rc = provision.run_provision(pool.name, project, mounts, verify=False)
             if rc != 0:
                 raise RemoTartError(
                     f"provision failed with exit code {rc}",
                     hint="re-run with -v for verbose pack output, or check guest logs",
                 )
+            _write_provisioned_hash(pool.name, current_hash)
 
     final_manifest = manifest_read(manifest_path)
     attachment = WorktreeAttachment(
@@ -164,6 +176,34 @@ def ensure_attached(
 # ---------------------------------------------------------------------------
 # Module-level helpers (patchable by tests)
 # ---------------------------------------------------------------------------
+
+
+def _read_provisioned_hash(vm_name: str) -> str | None:
+    """Return the previously-provisioned config hash for *vm_name*, or
+    None if the state file is missing or unreadable. ``None`` is
+    treated as "never provisioned" by the orchestrator and forces a
+    provision run.
+    """
+    path = provisioned_hash_path(vm_name)
+    try:
+        return path.read_text().strip() or None
+    except (FileNotFoundError, NotADirectoryError, PermissionError, OSError):
+        return None
+
+
+def _write_provisioned_hash(vm_name: str, value: str) -> None:
+    """Persist the most recently successfully-provisioned config hash.
+
+    Best-effort: an IO error here doesn't fail the attach (provision
+    already succeeded), it just means next ``up`` will re-provision —
+    correctness over efficiency.
+    """
+    path = provisioned_hash_path(vm_name)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value)
+    except OSError:
+        pass
 
 
 def _running_mount_names(vm_name: str) -> set[str]:

--- a/tools/remo-tart/src/remo_tart/worktree.py
+++ b/tools/remo-tart/src/remo_tart/worktree.py
@@ -14,7 +14,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from remo_tart import launchd, ssh, vm
+from remo_tart import launchd, provision, ssh, vm
 from remo_tart.config import ProjectConfig
 from remo_tart.console import done, get_console, step
 from remo_tart.errors import RemoTartError
@@ -121,7 +121,7 @@ def ensure_attached(
     umbrella_entry = MountEntry(name=pool.name, host_path=repo_root.resolve())
     manifest_write(manifest_path, [umbrella_entry])
 
-    vm_state = _read_state(pool)
+    vm_state = _read_state(pool, expected_mount=umbrella_entry)
 
     mounts = manifest_read(manifest_path)
     actions = decide(vm_state)
@@ -139,6 +139,14 @@ def ensure_attached(
 
     if vm.is_running(pool.name):
         _configure_ssh(project, pool, key_path)
+        if any(a != Action.NOTHING for a in actions):
+            step("running packs ensure + project provision hook")
+            rc = provision.run_provision(pool.name, project, mounts, verify=False)
+            if rc != 0:
+                raise RemoTartError(
+                    f"provision failed with exit code {rc}",
+                    hint="re-run with -v for verbose pack output, or check guest logs",
+                )
 
     final_manifest = manifest_read(manifest_path)
     attachment = WorktreeAttachment(
@@ -171,17 +179,68 @@ def _running_mount_names(vm_name: str) -> set[str]:
     return {line.strip() for line in result.stdout.splitlines() if line.strip()}
 
 
-def _read_state(pool: PoolConfig) -> VmState:
+def _running_mount_bindings(label_str: str) -> dict[str, Path] | None:
+    """Return ``{share_name: host_path}`` for the running ``tart run`` job.
+
+    Reads the launchd job's argv via :func:`launchd.running_tart_argv` and
+    extracts each ``--dir <name>:<host_path>`` pair. Returns ``None`` when
+    the job is not active so callers can distinguish "no job" from
+    "job has zero bindings".
+    """
+    argv = launchd.running_tart_argv(label_str)
+    if argv is None:
+        return None
+    bindings: dict[str, Path] = {}
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--dir" and i + 1 < len(argv):
+            spec = argv[i + 1]
+            if ":" in spec:
+                name, raw_path = spec.split(":", 1)
+                bindings[name] = Path(raw_path)
+            i += 2
+        else:
+            i += 1
+    return bindings
+
+
+def _read_state(pool: PoolConfig, expected_mount: MountEntry | None = None) -> VmState:
     """Read current VM state for *pool*.
 
-    ``mount_matches`` is True iff the running guest has the umbrella share
-    (named after the pool) visible under ``/Volumes/My Shared Files``.
+    ``mount_matches`` requires both:
+
+    1. The guest can see a share named ``pool.name`` under
+       ``/Volumes/My Shared Files/`` (ground truth from inside the VM).
+    2. The host-side ``tart run`` argv binds that share to
+       ``expected_mount.host_path`` (when provided). Comparing the host path
+       catches *manifest drift* — i.e. the manifest now says the umbrella
+       root but the running VM is still bound to a single worktree from a
+       previous attach.
+
+    When ``expected_mount`` is omitted, only the name-presence check runs
+    (preserves prior behaviour for callers that don't have an expectation).
     """
     name = pool.name
     exists = vm.exists(name)
     running = exists and vm.is_running(name)
-    mount_matches = pool.name in _running_mount_names(name) if running else False
-    return VmState(exists=exists, running=running, mount_matches=mount_matches)
+    if not running:
+        return VmState(exists=exists, running=False, mount_matches=False)
+
+    name_visible = pool.name in _running_mount_names(name)
+    if not name_visible:
+        return VmState(exists=exists, running=True, mount_matches=False)
+
+    if expected_mount is None:
+        return VmState(exists=exists, running=True, mount_matches=True)
+
+    bindings = _running_mount_bindings(launchd.label(name))
+    if bindings is None:
+        return VmState(exists=exists, running=True, mount_matches=False)
+    actual = bindings.get(pool.name)
+    if actual is None:
+        return VmState(exists=exists, running=True, mount_matches=False)
+    matches = actual.resolve() == expected_mount.host_path.resolve()
+    return VmState(exists=exists, running=True, mount_matches=matches)
 
 
 def _normalize_worktree_gitdirs(repo_root: Path) -> None:

--- a/tools/remo-tart/tests/test_launchd.py
+++ b/tools/remo-tart/tests/test_launchd.py
@@ -44,3 +44,82 @@ def test_job_present_false_when_launchctl_fails(tmp_path: Path) -> None:
     with patch("subprocess.run") as run:
         run.return_value.returncode = 1
         assert job_present("com.remo.tart.remo-dev") is False
+
+
+_LAUNCHCTL_PRINT_TEMPLATE = """\
+gui/501/com.remo.tart.remo-dev = {{
+\tactive count = 3
+\tstate = running
+
+\tprogram = /bin/zsh
+\targuments = {{
+\t\t/bin/zsh
+\t\t-lc
+\t\t{cmd}
+\t}}
+\tpid = 75144
+}}
+"""
+
+
+def _print_stub(returncode: int, stdout: str = "") -> object:
+    """Return a CompletedProcess-shaped MagicMock for subprocess.run."""
+    from unittest.mock import MagicMock
+
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    return proc
+
+
+def test_running_tart_argv_parses_dir_bindings() -> None:
+    from remo_tart.launchd import running_tart_argv
+
+    cmd = (
+        "exec tart run pulse-ios-dev-vm --net-bridged en0 "
+        "--dir pulse-ios-dev-vm:/Users/jane/Pulse "
+        "> /Users/jane/.config/remo/tart/pulse-ios-dev-vm.log 2>&1"
+    )
+    output = _LAUNCHCTL_PRINT_TEMPLATE.format(cmd=cmd)
+    with patch("subprocess.run", return_value=_print_stub(0, output)):
+        argv = running_tart_argv("com.remo.tart.pulse-ios-dev-vm")
+    assert argv is not None
+    assert argv[:3] == ["tart", "run", "pulse-ios-dev-vm"]
+    assert "--dir" in argv
+    assert "pulse-ios-dev-vm:/Users/jane/Pulse" in argv
+    assert ">" not in argv
+    assert "2>&1" not in argv
+
+
+def test_running_tart_argv_returns_none_when_job_absent() -> None:
+    from remo_tart.launchd import running_tart_argv
+
+    with patch("subprocess.run", return_value=_print_stub(1, "")):
+        assert running_tart_argv("com.remo.tart.nope") is None
+
+
+def test_running_tart_argv_returns_none_when_no_exec_line() -> None:
+    """`launchctl print` succeeded but did not contain an `exec tart` line —
+    e.g. a job submitted by something other than this module. We treat that
+    as "unknown" rather than crashing or matching partial junk."""
+    from remo_tart.launchd import running_tart_argv
+
+    with patch("subprocess.run", return_value=_print_stub(0, "no exec line here")):
+        assert running_tart_argv("com.remo.tart.foo") is None
+
+
+def test_running_tart_argv_handles_quoted_paths() -> None:
+    """Paths containing spaces are shell-quoted in the launchctl print output;
+    shlex must round-trip them as single tokens."""
+    from remo_tart.launchd import running_tart_argv
+
+    cmd = (
+        "exec tart run space-vm "
+        "--dir space-vm:'/Users/jane/With Space/Repo' "
+        "> '/log path/x.log' 2>&1"
+    )
+    output = _LAUNCHCTL_PRINT_TEMPLATE.format(cmd=cmd)
+    with patch("subprocess.run", return_value=_print_stub(0, output)):
+        argv = running_tart_argv("com.remo.tart.space-vm")
+    assert argv is not None
+    assert "space-vm:/Users/jane/With Space/Repo" in argv

--- a/tools/remo-tart/tests/test_paths.py
+++ b/tools/remo-tart/tests/test_paths.py
@@ -69,6 +69,91 @@ def test_find_repo_root_raises_when_not_found(tmp_path: Path) -> None:
     assert "project.toml" in excinfo.value.hint
 
 
+def _git_env() -> dict[str, str]:
+    return {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+
+
+def test_find_repo_root_in_linked_worktree_with_stray_tart_returns_main_repo(
+    tmp_path: Path,
+) -> None:
+    """When invoked from a linked worktree that *also* has its own .tart/
+    (e.g. an untracked stray copy or a tracked one), find_repo_root must
+    resolve to the main checkout via git --git-common-dir, not stop at the
+    worktree's first .tart/project.toml hit during an upward walk.
+
+    This is the failure mode that misconfigured pulse-ios-dev-vm in the field:
+    `umbrella_entry.host_path` ended up bound to a single worktree because
+    `find_repo_root` returned the worktree, not the project root.
+    """
+    import subprocess as sp
+
+    main = tmp_path / "main"
+    main.mkdir()
+    env = _git_env()
+    sp.run(
+        ["git", "-C", str(main), "init", "--initial-branch=main"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    _make_fake_repo(main)  # main checkout has .tart/
+    sp.run(["git", "-C", str(main), "add", "."], check=True, capture_output=True, env=env)
+    sp.run(
+        ["git", "-C", str(main), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    wt = main / ".worktrees" / "feature"
+    sp.run(
+        ["git", "-C", str(main), "worktree", "add", str(wt), "-b", "feature"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    # The worktree's checked-out tree contains its own .tart/project.toml
+    # (committed copy); this is the realistic in-the-field scenario.
+    assert (wt / ".tart" / "project.toml").is_file()
+
+    # Despite the worktree-local .tart/project.toml, find_repo_root must
+    # return main, not wt — git --git-common-dir disambiguates.
+    assert find_repo_root(wt) == main.resolve()
+    assert find_repo_root(wt / ".tart") == main.resolve()
+
+
+def test_find_repo_root_falls_back_to_walk_when_not_a_git_repo(tmp_path: Path) -> None:
+    """If --git-common-dir fails (not a git repo), fall back to upward walk."""
+    repo = _make_fake_repo(tmp_path)
+    nested = repo / "deeper"
+    nested.mkdir()
+    # tmp_path is not a git repo; --git-common-dir errors; walk handles it
+    assert find_repo_root(nested) == repo
+
+
+def test_find_repo_root_in_main_checkout_uses_git_common_dir(tmp_path: Path) -> None:
+    """Sanity: in a main checkout, --git-common-dir parent == repo root."""
+    import subprocess as sp
+
+    repo = _make_fake_repo(tmp_path)
+    env = _git_env()
+    sp.run(
+        ["git", "-C", str(repo), "init", "--initial-branch=main"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    sub = repo / "tools" / "x"
+    sub.mkdir(parents=True)
+    assert find_repo_root(sub) == repo.resolve()
+
+
 def test_git_worktree_root_in_main_checkout(tmp_path: Path) -> None:
     """In the main checkout, worktree root == repo root."""
     import subprocess as sp

--- a/tools/remo-tart/tests/test_provision.py
+++ b/tools/remo-tart/tests/test_provision.py
@@ -132,3 +132,167 @@ def test_run_provision_invokes_vm_exec_interactive(exec_i: MagicMock) -> None:
 def test_run_provision_propagates_nonzero(exec_i: MagicMock) -> None:
     exec_i.return_value = 7
     assert run_provision("remo-dev", _cfg(), _mounts(), verify=False) == 7
+
+
+# ---------------------------------------------------------------------------
+# config_hash (rebuild detection — issue #68 phase 1)
+# ---------------------------------------------------------------------------
+
+
+def _seed_repo(root: Path, *, pack_files: dict[str, str], provision_body: str) -> Path:
+    """Seed a fake repo at *root* with .tart/packs/ and provision.sh.
+
+    Returns *root* for chaining. Each entry of *pack_files* maps pack
+    basename (without .sh) to its content; `_lib.sh` is the only one
+    treated specially (the helper sources it). Pass an empty
+    *pack_files* to test missing-file handling.
+    """
+    packs = root / ".tart" / "packs"
+    packs.mkdir(parents=True, exist_ok=True)
+    for name, body in pack_files.items():
+        (packs / f"{name}.sh").write_text(body)
+    (root / ".tart" / "provision.sh").write_text(provision_body)
+    return root
+
+
+def test_config_hash_is_deterministic(tmp_path: Path) -> None:
+    from remo_tart.provision import config_hash
+
+    _seed_repo(
+        tmp_path,
+        pack_files={"_lib": "lib", "ios": "ios body", "node": "node body"},
+        provision_body="bootstrap",
+    )
+    cfg = _cfg(["ios", "node"])
+    h1 = config_hash(cfg, tmp_path)
+    h2 = config_hash(cfg, tmp_path)
+    assert h1 == h2
+    assert isinstance(h1, str)
+    assert len(h1) == 64  # sha256 hex
+
+
+def test_config_hash_changes_when_pack_added_to_enabled(tmp_path: Path) -> None:
+    """Adding a pack to enabled flips the hash even if no file content
+    changed (the new pack file already existed but wasn't being run)."""
+    from remo_tart.provision import config_hash
+
+    _seed_repo(
+        tmp_path,
+        pack_files={"_lib": "lib", "ios": "ios", "node": "node", "uv": "uv body"},
+        provision_body="bootstrap",
+    )
+    h_without_uv = config_hash(_cfg(["ios", "node"]), tmp_path)
+    h_with_uv = config_hash(_cfg(["ios", "node", "uv"]), tmp_path)
+    assert h_without_uv != h_with_uv
+
+
+def test_config_hash_changes_when_pack_content_changes(tmp_path: Path) -> None:
+    from remo_tart.provision import config_hash
+
+    _seed_repo(
+        tmp_path,
+        pack_files={"_lib": "lib", "ios": "ios v1"},
+        provision_body="bootstrap",
+    )
+    h_v1 = config_hash(_cfg(["ios"]), tmp_path)
+    (tmp_path / ".tart" / "packs" / "ios.sh").write_text("ios v2 — added mint check")
+    h_v2 = config_hash(_cfg(["ios"]), tmp_path)
+    assert h_v1 != h_v2
+
+
+def test_config_hash_changes_when_provision_changes(tmp_path: Path) -> None:
+    from remo_tart.provision import config_hash
+
+    _seed_repo(
+        tmp_path,
+        pack_files={"_lib": "lib", "ios": "ios"},
+        provision_body="mint bootstrap",
+    )
+    h1 = config_hash(_cfg(["ios"]), tmp_path)
+    (tmp_path / ".tart" / "provision.sh").write_text(
+        "mint bootstrap\nclaude plugin install figma@claude-plugins-official"
+    )
+    h2 = config_hash(_cfg(["ios"]), tmp_path)
+    assert h1 != h2
+
+
+def test_config_hash_changes_when_lib_changes(tmp_path: Path) -> None:
+    """`_lib.sh` is shared by all packs; any change there can affect
+    every pack's behaviour, so it must be in the hash."""
+    from remo_tart.provision import config_hash
+
+    _seed_repo(
+        tmp_path,
+        pack_files={"_lib": "lib v1", "ios": "ios"},
+        provision_body="bootstrap",
+    )
+    h1 = config_hash(_cfg(["ios"]), tmp_path)
+    (tmp_path / ".tart" / "packs" / "_lib.sh").write_text("lib v2 — new helper")
+    h2 = config_hash(_cfg(["ios"]), tmp_path)
+    assert h1 != h2
+
+
+def test_config_hash_ignores_vm_resource_changes(tmp_path: Path) -> None:
+    """Changing vm.cpu / memory / base_image shouldn't trigger reprovision —
+    those affect VM boot, not what's installed. Reprovisioning won't fix
+    them anyway. Doctor is the right place for that drift signal."""
+    from remo_tart.provision import config_hash
+
+    _seed_repo(
+        tmp_path,
+        pack_files={"_lib": "lib", "ios": "ios"},
+        provision_body="bootstrap",
+    )
+    cfg_small = _cfg(["ios"])
+    cfg_big = ProjectConfig(
+        slug="remo",
+        vm=VmConfig(
+            name="remo-dev",
+            base_image="img",
+            cpu=99,  # ← changed
+            memory_gb=64,  # ← changed
+            network="shared",
+        ),
+        packs=["ios"],
+        scripts=ScriptsConfig(
+            provision=".tart/provision.sh",
+            verify_worktree=".tart/verify-worktree.sh",
+        ),
+    )
+    assert config_hash(cfg_small, tmp_path) == config_hash(cfg_big, tmp_path)
+
+
+def test_config_hash_handles_missing_pack_file(tmp_path: Path) -> None:
+    """If a pack is enabled but its file doesn't exist, hash still
+    computes (so `up` doesn't crash with FileNotFoundError) but is
+    distinct from the same setup with the file present — so resolving
+    the missing file flips the hash."""
+    from remo_tart.provision import config_hash
+
+    (tmp_path / ".tart" / "packs").mkdir(parents=True)
+    (tmp_path / ".tart" / "packs" / "_lib.sh").write_text("lib")
+    (tmp_path / ".tart" / "provision.sh").write_text("bootstrap")
+    # Note: ios.sh deliberately not created.
+
+    h_missing = config_hash(_cfg(["ios"]), tmp_path)
+
+    (tmp_path / ".tart" / "packs" / "ios.sh").write_text("real content")
+    h_present = config_hash(_cfg(["ios"]), tmp_path)
+    assert h_missing != h_present
+
+
+def test_config_hash_pack_order_in_enabled_doesnt_matter_when_normalized(
+    tmp_path: Path,
+) -> None:
+    """``packs.enabled`` is sorted before hashing so reordering it in
+    project.toml doesn't trigger a spurious reprovision."""
+    from remo_tart.provision import config_hash
+
+    _seed_repo(
+        tmp_path,
+        pack_files={"_lib": "lib", "a": "a body", "b": "b body"},
+        provision_body="bootstrap",
+    )
+    h_ab = config_hash(_cfg(["a", "b"]), tmp_path)
+    h_ba = config_hash(_cfg(["b", "a"]), tmp_path)
+    assert h_ab == h_ba

--- a/tools/remo-tart/tests/test_worktree.py
+++ b/tools/remo-tart/tests/test_worktree.py
@@ -40,6 +40,7 @@ def fake_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
 @patch("remo_tart.worktree.vm.is_running", return_value=True)
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
@@ -49,6 +50,7 @@ def test_missing_vm_triggers_create(
     read: MagicMock,
     config_ssh: MagicMock,
     is_running: MagicMock,
+    run_provision: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
@@ -56,6 +58,7 @@ def test_missing_vm_triggers_create(
     outcome = ensure_attached(fake_repo, _cfg(), fake_repo)
     create.assert_called_once()
     config_ssh.assert_called_once()
+    run_provision.assert_called_once()
     assert isinstance(outcome, AttachOutcome)
     assert Action.CREATE in outcome.actions
 
@@ -83,6 +86,7 @@ def test_healthy_state_is_nothing_and_still_configures_ssh(
     config_ssh.assert_called_once()
 
 
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
 @patch("remo_tart.worktree.vm.is_running", return_value=True)
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
@@ -92,6 +96,7 @@ def test_running_with_mismatched_mount_triggers_update_and_restart(
     read: MagicMock,
     config_ssh: MagicMock,
     is_running: MagicMock,
+    run_provision: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
@@ -99,8 +104,10 @@ def test_running_with_mismatched_mount_triggers_update_and_restart(
     ensure_attached(fake_repo, _cfg(), fake_repo)
     update.assert_called_once()
     config_ssh.assert_called_once()
+    run_provision.assert_called_once()
 
 
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
 @patch("remo_tart.worktree.vm.is_running", return_value=True)
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
@@ -110,6 +117,7 @@ def test_stopped_with_matching_mount_triggers_start(
     read: MagicMock,
     config_ssh: MagicMock,
     is_running: MagicMock,
+    run_provision: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
@@ -117,6 +125,7 @@ def test_stopped_with_matching_mount_triggers_start(
     ensure_attached(fake_repo, _cfg(), fake_repo)
     start.assert_called_once()
     config_ssh.assert_called_once()
+    run_provision.assert_called_once()
 
 
 def test_ensure_attached_writes_single_umbrella_entry(fake_home: Path, fake_repo: Path) -> None:
@@ -522,3 +531,220 @@ def test_normalize_worktree_gitdirs_leaves_external_gitdir_alone(tmp_path: Path)
 
     _normalize_worktree_gitdirs(repo)
     assert (wt / ".git").read_text() == foreign
+
+
+# ---------------------------------------------------------------------------
+# _running_mount_bindings + _read_state (mount-drift detection)
+# ---------------------------------------------------------------------------
+
+
+def test_running_mount_bindings_extracts_dir_pairs() -> None:
+    from remo_tart.worktree import _running_mount_bindings
+
+    argv = [
+        "tart",
+        "run",
+        "pulse-ios-dev-vm",
+        "--net-bridged",
+        "en0",
+        "--dir",
+        "pulse-ios-dev-vm:/Users/jane/Pulse",
+        "--dir",
+        "secondary:/Users/jane/Other",
+    ]
+    with patch("remo_tart.worktree.launchd.running_tart_argv", return_value=argv):
+        bindings = _running_mount_bindings("com.remo.tart.pulse-ios-dev-vm")
+    assert bindings == {
+        "pulse-ios-dev-vm": Path("/Users/jane/Pulse"),
+        "secondary": Path("/Users/jane/Other"),
+    }
+
+
+def test_running_mount_bindings_returns_none_when_job_absent() -> None:
+    from remo_tart.worktree import _running_mount_bindings
+
+    with patch("remo_tart.worktree.launchd.running_tart_argv", return_value=None):
+        assert _running_mount_bindings("com.remo.tart.absent") is None
+
+
+def _pool_for(name: str) -> object:
+    from remo_tart.pool import PoolConfig
+
+    return PoolConfig(name=name)
+
+
+def test_read_state_not_running_returns_false() -> None:
+    from remo_tart.mount import MountEntry
+    from remo_tart.worktree import _read_state
+
+    pool = _pool_for("pulse-ios-dev-vm")
+    expected = MountEntry(name="pulse-ios-dev-vm", host_path=Path("/Users/jane/Pulse"))
+    with (
+        patch("remo_tart.worktree.vm.exists", return_value=True),
+        patch("remo_tart.worktree.vm.is_running", return_value=False),
+    ):
+        state = _read_state(pool, expected_mount=expected)
+    assert state.running is False
+    assert state.mount_matches is False
+
+
+def test_read_state_running_with_matching_host_path_matches(tmp_path: Path) -> None:
+    from remo_tart.mount import MountEntry
+    from remo_tart.worktree import _read_state
+
+    repo = tmp_path / "Pulse"
+    repo.mkdir()
+    pool = _pool_for("pulse-ios-dev-vm")
+    expected = MountEntry(name="pulse-ios-dev-vm", host_path=repo)
+    with (
+        patch("remo_tart.worktree.vm.exists", return_value=True),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch(
+            "remo_tart.worktree._running_mount_names",
+            return_value={"pulse-ios-dev-vm"},
+        ),
+        patch(
+            "remo_tart.worktree._running_mount_bindings",
+            return_value={"pulse-ios-dev-vm": repo},
+        ),
+    ):
+        state = _read_state(pool, expected_mount=expected)
+    assert state.running is True
+    assert state.mount_matches is True
+
+
+def test_read_state_running_with_drifted_host_path_does_not_match(tmp_path: Path) -> None:
+    """The running tart binds the share name to a different host path than
+    the manifest's umbrella entry — this is the field-observed bug. Must
+    return mount_matches=False so ensure_attached restarts the VM."""
+    from remo_tart.mount import MountEntry
+    from remo_tart.worktree import _read_state
+
+    repo = tmp_path / "Pulse"
+    repo.mkdir()
+    worktree = repo / ".worktrees" / "feat"
+    worktree.mkdir(parents=True)
+    pool = _pool_for("pulse-ios-dev-vm")
+    expected = MountEntry(name="pulse-ios-dev-vm", host_path=repo)
+    with (
+        patch("remo_tart.worktree.vm.exists", return_value=True),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch(
+            "remo_tart.worktree._running_mount_names",
+            return_value={"pulse-ios-dev-vm"},
+        ),
+        patch(
+            "remo_tart.worktree._running_mount_bindings",
+            return_value={"pulse-ios-dev-vm": worktree},  # drifted!
+        ),
+    ):
+        state = _read_state(pool, expected_mount=expected)
+    assert state.running is True
+    assert state.mount_matches is False
+
+
+def test_read_state_running_share_name_missing_does_not_match(tmp_path: Path) -> None:
+    from remo_tart.mount import MountEntry
+    from remo_tart.worktree import _read_state
+
+    pool = _pool_for("pulse-ios-dev-vm")
+    expected = MountEntry(name="pulse-ios-dev-vm", host_path=tmp_path)
+    with (
+        patch("remo_tart.worktree.vm.exists", return_value=True),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch("remo_tart.worktree._running_mount_names", return_value=set()),
+    ):
+        state = _read_state(pool, expected_mount=expected)
+    assert state.mount_matches is False
+
+
+def test_read_state_without_expected_mount_falls_back_to_name_only(tmp_path: Path) -> None:
+    """Backwards-compat: omitting expected_mount preserves the old name-only
+    check. Useful for callers that haven't been updated yet."""
+    from remo_tart.worktree import _read_state
+
+    pool = _pool_for("pulse-ios-dev-vm")
+    with (
+        patch("remo_tart.worktree.vm.exists", return_value=True),
+        patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch(
+            "remo_tart.worktree._running_mount_names",
+            return_value={"pulse-ios-dev-vm"},
+        ),
+    ):
+        state = _read_state(pool)
+    assert state.mount_matches is True
+
+
+# ---------------------------------------------------------------------------
+# provision wiring (Fix #3)
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_nothing")
+def test_provision_skipped_when_only_nothing_action(
+    nothing: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    is_running: MagicMock,
+    run_provision: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    """When the VM is already in the desired state (NOTHING action),
+    provision must NOT re-run — packs ensure is idempotent but expensive
+    (npm/brew network calls) and unnecessary."""
+    read.return_value = VmState(exists=True, running=True, mount_matches=True)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+    nothing.assert_called_once()
+    config_ssh.assert_called_once()
+    run_provision.assert_not_called()
+
+
+@patch("remo_tart.worktree.provision.run_provision", return_value=2)
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_create")
+def test_provision_failure_raises(
+    create: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    is_running: MagicMock,
+    run_provision: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    from remo_tart.errors import RemoTartError
+
+    read.return_value = VmState(exists=False, running=False, mount_matches=False)
+    with pytest.raises(RemoTartError) as excinfo:
+        ensure_attached(fake_repo, _cfg(), fake_repo)
+    assert "exit code 2" in str(excinfo.value)
+
+
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_create")
+def test_provision_called_with_verify_false(
+    create: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    is_running: MagicMock,
+    run_provision: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    """Per-attach provisioning must not run verify-worktree.sh — that's a
+    user-facing first-build step, not a default for every attach (which
+    would multiply attach time by full xcodebuild duration)."""
+    read.return_value = VmState(exists=False, running=False, mount_matches=False)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+    _, kwargs = run_provision.call_args
+    assert kwargs.get("verify") is False

--- a/tools/remo-tart/tests/test_worktree.py
+++ b/tools/remo-tart/tests/test_worktree.py
@@ -63,6 +63,7 @@ def test_missing_vm_triggers_create(
     assert Action.CREATE in outcome.actions
 
 
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
 @patch("remo_tart.worktree._action_nothing")
@@ -72,6 +73,7 @@ def test_healthy_state_is_nothing_and_still_configures_ssh(
     nothing: MagicMock,
     read: MagicMock,
     config_ssh: MagicMock,
+    run_provision: MagicMock,
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
@@ -137,6 +139,7 @@ def test_ensure_attached_writes_single_umbrella_entry(fake_home: Path, fake_repo
         patch("remo_tart.worktree._action_nothing"),
         patch("remo_tart.worktree._configure_ssh"),
         patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch("remo_tart.worktree.provision.run_provision", return_value=0),
     ):
         read.return_value = VmState(exists=True, running=True, mount_matches=True)
         ensure_attached(fake_repo, _cfg(), fake_repo)
@@ -167,6 +170,7 @@ def test_ensure_attached_drops_legacy_manifest_entries(fake_home: Path, fake_rep
         patch("remo_tart.worktree._action_nothing"),
         patch("remo_tart.worktree._configure_ssh"),
         patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch("remo_tart.worktree.provision.run_provision", return_value=0),
     ):
         read.return_value = VmState(exists=True, running=True, mount_matches=True)
         ensure_attached(fake_repo, _cfg(), fake_repo)
@@ -184,6 +188,7 @@ def test_ensure_attached_uses_pool_name_when_provided(fake_home: Path, fake_repo
         patch("remo_tart.worktree._action_nothing"),
         patch("remo_tart.worktree._configure_ssh"),
         patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch("remo_tart.worktree.provision.run_provision", return_value=0),
     ):
         read.return_value = VmState(exists=True, running=True, mount_matches=True)
         outcome = ensure_attached(fake_repo, _cfg(), fake_repo, pool_name="alpha")
@@ -390,6 +395,7 @@ def test_attach_outcome_carries_attachment(fake_home: Path, fake_repo: Path) -> 
         patch("remo_tart.worktree._action_nothing"),
         patch("remo_tart.worktree._configure_ssh"),
         patch("remo_tart.worktree.vm.is_running", return_value=True),
+        patch("remo_tart.worktree.provision.run_provision", return_value=0),
     ):
         read.return_value = VmState(exists=True, running=True, mount_matches=True)
         outcome = ensure_attached(fake_repo, _cfg(), fake_repo)
@@ -686,7 +692,7 @@ def test_read_state_without_expected_mount_falls_back_to_name_only(tmp_path: Pat
 @patch("remo_tart.worktree._configure_ssh")
 @patch("remo_tart.worktree._read_state")
 @patch("remo_tart.worktree._action_nothing")
-def test_provision_skipped_when_only_nothing_action(
+def test_provision_skipped_when_nothing_action_and_hash_matches(
     nothing: MagicMock,
     read: MagicMock,
     config_ssh: MagicMock,
@@ -695,9 +701,20 @@ def test_provision_skipped_when_only_nothing_action(
     fake_home: Path,
     fake_repo: Path,
 ) -> None:
-    """When the VM is already in the desired state (NOTHING action),
-    provision must NOT re-run — packs ensure is idempotent but expensive
-    (npm/brew network calls) and unnecessary."""
+    """When the VM is already in the desired state AND on-disk config
+    matches what was last provisioned, provision must NOT re-run —
+    packs ensure is idempotent but expensive (npm/brew network calls)
+    and unnecessary."""
+    from remo_tart import provision
+    from remo_tart.paths import provisioned_hash_path
+
+    # Pre-write the state file with the matching hash so the drift
+    # check sees no change since last provision.
+    expected_hash = provision.config_hash(_cfg(), fake_repo)
+    state_path = provisioned_hash_path("remo-dev")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(expected_hash)
+
     read.return_value = VmState(exists=True, running=True, mount_matches=True)
     ensure_attached(fake_repo, _cfg(), fake_repo)
     nothing.assert_called_once()
@@ -748,3 +765,121 @@ def test_provision_called_with_verify_false(
     ensure_attached(fake_repo, _cfg(), fake_repo)
     _, kwargs = run_provision.call_args
     assert kwargs.get("verify") is False
+
+
+# ---------------------------------------------------------------------------
+# config-hash drift handling (issue #68 phase 1)
+# ---------------------------------------------------------------------------
+
+
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_nothing")
+def test_provision_runs_on_config_drift_even_when_action_is_nothing(
+    nothing: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    is_running: MagicMock,
+    run_provision: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    """If the on-disk config hash differs from the last-provisioned
+    hash, provision must run even when the VM-state machine returns
+    NOTHING. This is the bug where a user adds a pack to enabled and
+    `remo-tart up` silently skips the new pack."""
+    from remo_tart.paths import provisioned_hash_path
+
+    # Pre-write a stale hash so drift is detected.
+    state_path = provisioned_hash_path("remo-dev")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("stale-hash-from-an-earlier-config")
+
+    read.return_value = VmState(exists=True, running=True, mount_matches=True)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+    nothing.assert_called_once()
+    run_provision.assert_called_once()
+
+
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_nothing")
+def test_provision_runs_on_first_attach_when_no_state_file(
+    nothing: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    is_running: MagicMock,
+    run_provision: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    """A missing state file is treated as 'never provisioned', forcing
+    a provision run. This makes `up` self-healing if the state file is
+    deleted (or if a user manually `tart delete`'s and the hash file
+    leaks across) — better to reprovision than silently skip."""
+    read.return_value = VmState(exists=True, running=True, mount_matches=True)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+    run_provision.assert_called_once()
+
+
+@patch("remo_tart.worktree.provision.run_provision", return_value=0)
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_create")
+def test_provision_writes_hash_after_success(
+    create: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    is_running: MagicMock,
+    run_provision: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    """Successful provision persists the hash that was provisioned, so
+    the next `up` knows what was installed."""
+    from remo_tart.paths import provisioned_hash_path
+    from remo_tart.provision import config_hash
+
+    read.return_value = VmState(exists=False, running=False, mount_matches=False)
+    ensure_attached(fake_repo, _cfg(), fake_repo)
+
+    expected = config_hash(_cfg(), fake_repo)
+    actual = provisioned_hash_path("remo-dev").read_text().strip()
+    assert actual == expected
+
+
+@patch("remo_tart.worktree.provision.run_provision", return_value=2)
+@patch("remo_tart.worktree.vm.is_running", return_value=True)
+@patch("remo_tart.worktree._configure_ssh")
+@patch("remo_tart.worktree._read_state")
+@patch("remo_tart.worktree._action_create")
+def test_provision_failure_does_not_update_hash(
+    create: MagicMock,
+    read: MagicMock,
+    config_ssh: MagicMock,
+    is_running: MagicMock,
+    run_provision: MagicMock,
+    fake_home: Path,
+    fake_repo: Path,
+) -> None:
+    """When provision fails, the state file must not be updated to the
+    failed-config hash — otherwise next `up` would think the (broken)
+    config is already installed and skip retrying."""
+    from remo_tart.errors import RemoTartError
+    from remo_tart.paths import provisioned_hash_path
+
+    state_path = provisioned_hash_path("remo-dev")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("stale-hash")
+
+    read.return_value = VmState(exists=False, running=False, mount_matches=False)
+    with pytest.raises(RemoTartError):
+        ensure_attached(fake_repo, _cfg(), fake_repo)
+
+    # Hash file is unchanged (still stale) so next attempt re-tries.
+    assert state_path.read_text() == "stale-hash"


### PR DESCRIPTION
Fixes the three bugs documented in #66 that combined to make
`remo-tart up` look successful while leaving the VM in an
unusable, base-image state.

## Summary

- `paths.find_repo_root` now resolves via `git rev-parse --git-common-dir`
  first, so an upward walk that hits a worktree-local `.tart/project.toml`
  (the realistic scenario when `.tart/` is committed) no longer returns
  the worktree as `repo_root`. Falls back to the upward walk for non-git
  directories.
- `launchd.running_tart_argv` parses the `arguments` block of
  `launchctl print` to recover the live argv of the managed `tart run`
  process. Handles shell-quoted paths via `shlex`.
- `worktree._running_mount_bindings` turns the argv into
  `{share_name: host_path}`. `_read_state` now accepts `expected_mount`
  and only reports `mount_matches=True` when both the in-guest share
  name *and* the host_path the running tart process is bound to match
  the manifest. This catches the umbrella → worktree drift that #66
  describes; previously the name-only check let stale bindings persist
  forever.
- `ensure_attached` now calls `provision.run_provision(verify=False)`
  whenever a non-`NOTHING` action ran. The function existed and was
  unit-tested but had no live caller, so packs ensure (omz, mint, node,
  claude) and `provision.sh` never executed — even on a brand-new VM.
  Skipping on `NOTHING` keeps steady-state re-attaches free.

## Real-world repro this fixes

While bringing up `pulse-ios-dev-vm` for an iOS project (PR author's
day-to-day), the user observed:

```
$ remo-tart up vscode --display
VM 'pulse-ios-dev-vm' is already running with the correct mount. Nothing to do.
$ ssh pulse-ios-dev-vm 'echo $ZSH; ls ~/.oh-my-zsh 2>&1; ls -la .git'
                                            # ← omz absent
ls: /Users/admin/.oh-my-zsh: No such file or directory
-rw-r--r-- 1 admin staff 52 .git            # ← gitdir pointer to host-only path
$ ps -ef | grep 'tart run pulse-ios'
... tart run pulse-ios-dev-vm ... --dir pulse-ios-dev-vm:.../.worktrees/feat-comment-scrolling
                                            # ← bound to a single worktree, not the umbrella
```

Recovery before this PR required:
`launchctl bootout` + manual manifest rewrite + `tart delete` +
`uv run python -c 'provision.run_provision(...)'` from a host-side REPL.

After this PR: `remo-tart up vscode --display` boots, ensures every pack,
runs `provision.sh`, and connects VS Code Remote SSH in one command.

## Tests

- 199 passing (was 182 baseline). +17 new tests:
  - 4× `find_repo_root`: linked-worktree-with-stray-`.tart`, fallback to
    walk when no git, main-checkout sanity, error-when-not-found
    (preserved).
  - 4× `launchd.running_tart_argv`: dir bindings parsing, missing job,
    no `exec tart` line, quoted-path round-trip.
  - 6× `worktree._running_mount_bindings` + `_read_state`: matching path,
    drifted path, missing share name, not running, no expected mount
    (back-compat).
  - 3× provision wiring: skipped on `NOTHING`, raises on nonzero exit,
    called with `verify=False`.
- `ruff check` + `ruff format --check` clean.
- Pre-commit hook (cargo fmt + clippy + ruff) passes.

## Test plan

- [x] `uv run pytest` in `tools/remo-tart` — 199 pass
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] End-to-end on a fresh `tart delete <pool>` + `remo-tart up vscode --display` — manually verify omz / mint / claude land in the guest and `git status` works inside the VM. (Will validate against `pulse-ios-dev-vm` separately and report.)

Refs #66.