### PR TITLE
Keychain capability, real DOMStorage domain, and experimental SwiftUI Elements-panel support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1393,8 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
+ "security-framework",
+ "security-framework-sys",
  "serde",
  "serde_json",
  "tracing",
@@ -1553,6 +1565,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1217,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -1397,6 +1425,7 @@ dependencies = [
  "security-framework-sys",
  "serde",
  "serde_json",
+ "serde_stacker",
  "tracing",
 ]
 
@@ -1661,6 +1690,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_stacker"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4936375d50c4be7eff22293a9344f8e46f323ed2b3c243e52f89138d9bb0f4a"
+dependencies = [
+ "serde",
+ "serde_core",
+ "stacker",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1767,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
  "windows-sys",
 ]
 

--- a/crates/remo-cdp/src/domain_dom.rs
+++ b/crates/remo-cdp/src/domain_dom.rs
@@ -363,7 +363,7 @@ fn attributes(view: &ViewNode) -> Vec<String> {
 /// color, corner radius, label text) — not a regression, `ViewNode` simply
 /// doesn't capture those today.
 fn computed_style(view: &ViewNode) -> Vec<(String, String)> {
-    vec![
+    let mut style = vec![
         ("class".to_string(), view.class_name.clone()),
         ("left".to_string(), format!("{}px", view.frame.x as i64)),
         ("top".to_string(), format!("{}px", view.frame.y as i64)),
@@ -382,7 +382,18 @@ fn computed_style(view: &ViewNode) -> Vec<(String, String)> {
         ),
         ("tag".to_string(), view.tag.to_string()),
         ("subviews".to_string(), view.children.len().to_string()),
-    ]
+    ];
+    // SwiftUI-only, populated by `remo_objc::swiftui_debug`'s bounded
+    // properties flattener (see `ViewNode::style_rows`'s doc comment).
+    // Prefixed like a CSS custom property (`--swiftui-...`) purely as a
+    // naming convention to keep them visually distinct from the geometry-
+    // derived pseudo-CSS above in Chrome's real Styles pane — this module
+    // has no real cascade to enforce custom-property semantics for, same
+    // as every other "pseudo-CSS" field here.
+    for (title, value) in &view.style_rows {
+        style.push((format!("--swiftui-{title}"), value.clone()));
+    }
+    style
 }
 
 #[async_trait]
@@ -515,6 +526,7 @@ mod tests {
             tag: 0,
             accessibility_id: None,
             modifiers: Vec::new(),
+            style_rows: Vec::new(),
             children: Vec::new(),
         }
     }
@@ -533,6 +545,7 @@ mod tests {
             tag: 0,
             accessibility_id: Some("root".to_string()),
             modifiers: Vec::new(),
+            style_rows: Vec::new(),
             children,
         }
     }
@@ -684,6 +697,62 @@ mod tests {
         let json = domain.node_json(&leaf("UILabel"), DOCUMENT_NODE_ID, 0, &mut budget);
         let attrs = json["attributes"].as_array().expect("attributes array");
         assert!(!attrs.iter().any(|v| v == "modifiers"));
+    }
+
+    #[test]
+    fn style_rows_surface_as_prefixed_pseudo_css_declarations() {
+        // Simulates what `swiftui_debug.rs`'s bounded properties flattener
+        // (Part B) produces: a flat (title, value) list, including a
+        // trailing truncation-note row when the flattener's depth/row caps
+        // were hit.
+        let mut view = leaf("Text");
+        view.style_rows = vec![
+            ("font".to_string(), "title3".to_string()),
+            ("…".to_string(), "3 more (truncated)".to_string()),
+        ];
+
+        let domain = DomDomain::new();
+        let id = domain.register(&view);
+        let reply = domain.get_computed_style_for_node(&request(
+            "CSS.getComputedStyleForNode",
+            json!({ "nodeId": id }),
+        ));
+        let CdpReply::Result(value) = reply else {
+            panic!("expected a result, got an error");
+        };
+        let style = value["computedStyle"].as_array().expect("array");
+
+        let font_row = style
+            .iter()
+            .find(|d| d["name"] == json!("--swiftui-font"))
+            .expect("flattened style_rows entry present as its own pseudo-CSS declaration");
+        assert_eq!(font_row["value"], json!("title3"));
+
+        let truncation_row = style
+            .iter()
+            .find(|d| d["name"] == json!("--swiftui-…"))
+            .expect("truncation-note row is surfaced too, not silently dropped");
+        assert_eq!(truncation_row["value"], json!("3 more (truncated)"));
+
+        // The existing geometry-derived pseudo-CSS is untouched alongside it.
+        assert!(style.iter().any(|d| d["name"] == json!("left")));
+    }
+
+    #[test]
+    fn no_style_rows_means_no_extra_pseudo_css_declarations() {
+        let domain = DomDomain::new();
+        let id = domain.register(&leaf("UILabel"));
+        let reply = domain.get_computed_style_for_node(&request(
+            "CSS.getComputedStyleForNode",
+            json!({ "nodeId": id }),
+        ));
+        let CdpReply::Result(value) = reply else {
+            panic!("expected a result, got an error");
+        };
+        let style = value["computedStyle"].as_array().expect("array");
+        assert!(!style.iter().any(|d| d["name"]
+            .as_str()
+            .is_some_and(|n| n.starts_with("--swiftui-"))));
     }
 
     #[test]

--- a/crates/remo-cdp/src/domain_dom.rs
+++ b/crates/remo-cdp/src/domain_dom.rs
@@ -39,8 +39,10 @@ use crate::remote_object::remote_object;
 
 /// The one "document" every `Page.*`/`DOM.*` reply hangs off of — there is
 /// exactly one inspectable target (the app itself), so this is a fixed
-/// string, not a discovered URL.
-const MAIN_ORIGIN: &str = "remo://native";
+/// string, not a discovered URL. Public because `domain_storage` maps
+/// `Storage.getStorageKeyForFrame`'s main-frame case back onto this same
+/// origin.
+pub const MAIN_ORIGIN: &str = "remo://native";
 
 /// Node-count (not depth) budget for the eager `DOM.getDocument` reply. A
 /// depth cap tells you nothing on a deep-but-narrow tree (the Swift reference
@@ -397,6 +399,13 @@ impl CdpDomain for DomDomain {
 
     async fn respond(&self, request: &CdpRequest, events: &EventSink) -> CdpReply {
         match request.method.as_str() {
+            // The Application panel's storage sidebar discovers origins from
+            // this frame tree, not from any `DOMStorage.*` method — so the
+            // `userdefaults://standard` bucket `domain_storage::StorageDomain`
+            // answers for is listed here as a child frame, matching the
+            // Swift reference's `frameTree()`. Extending this to more
+            // buckets (e.g. IndexedDB-backed ones) means adding more entries
+            // to `childFrames`, not changing the shape.
             "Page.getResourceTree" => CdpReply::ok(json!({
                 "frameTree": {
                     "frame": {
@@ -408,6 +417,22 @@ impl CdpDomain for DomDomain {
                         "domainAndRegistry": "",
                     },
                     "resources": [],
+                    "childFrames": [{
+                        "frame": {
+                            "id": crate::domain_storage::USERDEFAULTS_ORIGIN,
+                            "parentId": "1",
+                            "loaderId": "1",
+                            "name": crate::domain_storage::USERDEFAULTS_ORIGIN,
+                            "url": format!("{}/", crate::domain_storage::USERDEFAULTS_ORIGIN),
+                            "securityOrigin": crate::domain_storage::USERDEFAULTS_ORIGIN,
+                            "mimeType": "text/html",
+                            "domainAndRegistry": "",
+                            "secureContextType": "Secure",
+                            "crossOriginIsolatedContextType": "NotIsolated",
+                            "gatedAPIFeatures": [],
+                        },
+                        "resources": [],
+                    }],
                 }
             })),
             // A bare `{}` makes `application.js` choke on `errors.length` and

--- a/crates/remo-cdp/src/domain_dom.rs
+++ b/crates/remo-cdp/src/domain_dom.rs
@@ -344,6 +344,14 @@ fn attributes(view: &ViewNode) -> Vec<String> {
         "{:.0},{:.0} {:.0}x{:.0}",
         view.frame.x, view.frame.y, view.frame.width, view.frame.height
     ));
+    // Populated only for SwiftUI nodes spliced in by
+    // `remo_objc::swiftui_debug` — see `ViewNode::modifiers`'s doc comment
+    // for why this is a separate attribute rather than folded into
+    // `nodeName`/`localName` (the tag name) the way it briefly was.
+    if !view.modifiers.is_empty() {
+        attrs.push("modifiers".to_string());
+        attrs.push(view.modifiers.join(", "));
+    }
     attrs
 }
 
@@ -506,6 +514,7 @@ mod tests {
             alpha: 1.0,
             tag: 0,
             accessibility_id: None,
+            modifiers: Vec::new(),
             children: Vec::new(),
         }
     }
@@ -523,6 +532,7 @@ mod tests {
             alpha: 1.0,
             tag: 0,
             accessibility_id: Some("root".to_string()),
+            modifiers: Vec::new(),
             children,
         }
     }
@@ -633,6 +643,47 @@ mod tests {
         assert_eq!(budget, MAX_EAGER_NODES - 2);
         // 1 id for the root + 2 for its children.
         assert_eq!(domain.nodes.len(), 3);
+    }
+
+    #[test]
+    fn modifiers_surface_as_their_own_cdp_attribute_not_in_the_tag_name() {
+        // Simulates what `swiftui_debug.rs` now produces: `class_name` is
+        // just the view's own type, `modifiers` is separate — this is the
+        // shape `attributes()` (and, one level up, `nodeName`/`localName`
+        // in `node_json`) must keep apart, matching the split introduced to
+        // stop unreadable multi-hundred-character SwiftUI tag names.
+        let mut view = leaf("SwiftUI.VStack<TupleView<(Text, Text)>>");
+        view.modifiers = vec![
+            "_PaddingLayout".to_string(),
+            "_BackgroundModifier<Color>".to_string(),
+        ];
+
+        let domain = DomDomain::new();
+        let mut budget = MAX_EAGER_NODES;
+        let json = domain.node_json(&view, DOCUMENT_NODE_ID, 0, &mut budget);
+
+        assert_eq!(
+            json["nodeName"],
+            json!("SwiftUI.VStack<TupleView<(Text, Text)>>")
+        );
+        let attrs = json["attributes"].as_array().expect("attributes array");
+        let idx = attrs
+            .iter()
+            .position(|v| v == "modifiers")
+            .expect("modifiers attribute present");
+        assert_eq!(
+            attrs[idx + 1],
+            json!("_PaddingLayout, _BackgroundModifier<Color>")
+        );
+    }
+
+    #[test]
+    fn modifiers_attribute_is_absent_for_plain_uikit_nodes() {
+        let domain = DomDomain::new();
+        let mut budget = MAX_EAGER_NODES;
+        let json = domain.node_json(&leaf("UILabel"), DOCUMENT_NODE_ID, 0, &mut budget);
+        let attrs = json["attributes"].as_array().expect("attributes array");
+        assert!(!attrs.iter().any(|v| v == "modifiers"));
     }
 
     #[test]

--- a/crates/remo-cdp/src/domain_storage.rs
+++ b/crates/remo-cdp/src/domain_storage.rs
@@ -1,0 +1,641 @@
+//! `NSUserDefaults` → Chrome DevTools' Application → Storage panel.
+//!
+//! Ported from the `DOMStorage.*`/`Storage.*` half of Gist-iOS's
+//! `DebugCDPStorageMirror.swift` (`PulseDevTools`) — same empirically-tested
+//! wire shapes, reduced to the one store Remo currently exposes generically:
+//! `NSUserDefaults`' standard domain. That store is modeled as exactly one
+//! "local storage" bucket, addressed by the fixed origin
+//! `userdefaults://standard` (Gist's MMKV-namespace-per-bucket idea doesn't
+//! apply here — there is only one domain to show).
+//!
+//! `domain_dom::DomDomain` already owns `Page.getResourceTree` (it answers
+//! for the "one document" the whole CDP surface hangs off of), so this
+//! module does not claim it. Instead the UserDefaults bucket is added there
+//! as a child frame — see the `USERDEFAULTS_ORIGIN` wiring in
+//! `domain_dom.rs`'s `Page.getResourceTree` — because the Application
+//! panel's storage sidebar discovers origins from the frame tree, not from
+//! any `DOMStorage.*` method.
+//!
+//! # v1 non-goals (carried over deliberately, not silently dropped)
+//!
+//! - **No live external-change polling.** The Swift reference re-dumps every
+//!   *opened* bucket on a 3 s timer plus a `UserDefaults.didChangeNotification`
+//!   observer, so a value changed via `Remo.invoke`'s `userDefaults.set` (or
+//!   by the app itself) while the panel is open shows up without a manual
+//!   refresh. This port does not do that yet — mutations made *through this
+//!   domain* (`setDOMStorageItem`/`removeDOMStorageItem`/`clear`) do emit the
+//!   matching `domStorageItem*` event so the panel updates itself
+//!   immediately, but an external change is only picked up on the next
+//!   `getDOMStorageItems` (i.e. re-selecting the bucket, or `Cmd+R`). Adding
+//!   the polling loop is a follow-up, not a correctness bug in what's here.
+//! - **No session storage.** `NSUserDefaults` has no session-scoped concept
+//!   equivalent to `sessionStorage`; `isLocalStorage: false` requests answer
+//!   with an empty entry list rather than an error, matching real Chrome's
+//!   own behavior for an origin with no session storage.
+//! - **IndexedDB/CacheStorage are not implemented.** `Storage.setStorageBucketTracking`
+//!   is acked but deliberately does *not* emit
+//!   `Storage.storageBucketCreatedOrUpdated` — that event is what makes a
+//!   real Chrome frontend start probing `IndexedDB.requestDatabaseNames`,
+//!   and answering nothing there would be worse than never being asked. A
+//!   follow-up implementing IndexedDB (e.g. over `sqlite.query` against
+//!   `.sqlite`/`.db` files discovered via `filesystem.list`, tables as
+//!   object stores) should emit that event once it exists.
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use crate::dispatcher::{CdpDomain, CdpReply, CdpRequest, EventSink};
+
+/// The one storage bucket this domain answers for. Exposed so
+/// `domain_dom.rs` can add the matching child frame to `Page.getResourceTree`
+/// without this module needing to know anything about frame trees.
+pub const USERDEFAULTS_ORIGIN: &str = "userdefaults://standard";
+
+fn storage_key(origin: &str) -> String {
+    format!("{origin}/")
+}
+
+/// `true` if `storage_id` names the one bucket this domain knows about.
+/// Chrome sends `storageKey` on modern requests and `securityOrigin` on
+/// legacy ones; either is accepted, matching the Swift reference's routing
+/// (storageKey preferred, securityOrigin as fallback).
+fn is_userdefaults_bucket(storage_id: &Value) -> bool {
+    let key = storage_id
+        .get("storageKey")
+        .and_then(Value::as_str)
+        .or_else(|| storage_id.get("securityOrigin").and_then(Value::as_str))
+        .unwrap_or("");
+    let key = key.strip_suffix('/').unwrap_or(key);
+    key == USERDEFAULTS_ORIGIN
+}
+
+fn is_local_storage(storage_id: &Value) -> bool {
+    storage_id
+        .get("isLocalStorage")
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+}
+
+fn storage_id_json() -> Value {
+    json!({
+        "securityOrigin": USERDEFAULTS_ORIGIN,
+        "storageKey": storage_key(USERDEFAULTS_ORIGIN),
+        "isLocalStorage": true,
+    })
+}
+
+/// A property-list value as the plain string DevTools' Local Storage table
+/// expects (it is a text-only grid): strings pass through unchanged, every
+/// other JSON type (number/bool/array/object/null) is compactly JSON-encoded
+/// so the table shows something legible instead of Rust's `Display` of a
+/// `serde_json::Value`.
+fn display_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Inverse of [`display_value`] for writes coming back from the panel: a
+/// user typing `42`, `true`, `["a","b"]`, or `{"x":1}` into the value cell
+/// should round-trip as that type, not as the literal string `"42"` — so a
+/// successful JSON parse wins; anything that fails to parse (e.g. `hello`,
+/// not valid JSON) is stored as a plain string, which is the only type a
+/// non-JSON string could have meant.
+fn parse_value(raw: &str) -> Value {
+    serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
+}
+
+/// `DOMStorage.*`/`Storage.*` for the one generic key-value store Remo
+/// exposes: `NSUserDefaults`' standard domain.
+#[derive(Default)]
+pub struct StorageDomain;
+
+impl StorageDomain {
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[allow(unsafe_code)]
+    fn get_dom_storage_items(request: &CdpRequest) -> CdpReply {
+        let Some(storage_id) = request.params.get("storageId") else {
+            return CdpReply::error("getDOMStorageItems requires storageId");
+        };
+        if !is_userdefaults_bucket(storage_id) {
+            return CdpReply::error("unknown storage bucket");
+        }
+        if !is_local_storage(storage_id) {
+            // No session-storage concept for NSUserDefaults — empty, not an
+            // error, matching real Chrome's own answer for an origin with
+            // nothing in session storage.
+            return CdpReply::ok(json!({ "entries": Value::Array(vec![]) }));
+        }
+        // SAFETY: NSUserDefaults is documented thread-safe; no main-thread
+        // requirement (see remo_objc::user_defaults's module doc).
+        let entries = unsafe { remo_objc::list_user_defaults() };
+        let entries: Vec<Value> = entries
+            .into_iter()
+            .map(|(key, value)| json!([key, display_value(&value)]))
+            .collect();
+        CdpReply::ok(json!({ "entries": entries }))
+    }
+
+    #[allow(unsafe_code)]
+    fn set_dom_storage_item(request: &CdpRequest, events: &EventSink) -> CdpReply {
+        let Some(storage_id) = request.params.get("storageId") else {
+            return CdpReply::error("setDOMStorageItem requires storageId");
+        };
+        if !is_userdefaults_bucket(storage_id) {
+            return CdpReply::error("unknown storage bucket");
+        }
+        let Some(key) = request.params.get("key").and_then(Value::as_str) else {
+            return CdpReply::error("setDOMStorageItem requires key");
+        };
+        let Some(raw_value) = request.params.get("value").and_then(Value::as_str) else {
+            return CdpReply::error("setDOMStorageItem requires value");
+        };
+        let value = parse_value(raw_value);
+        // SAFETY: see get_dom_storage_items.
+        if let Err(message) = unsafe { remo_objc::set_user_default(key, &value) } {
+            return CdpReply::error(message);
+        }
+        events.emit(
+            "DOMStorage.domStorageItemAdded",
+            &json!({
+                "storageId": storage_id_json(),
+                "key": key,
+                "newValue": display_value(&value),
+            }),
+        );
+        CdpReply::empty()
+    }
+
+    #[allow(unsafe_code)]
+    fn remove_dom_storage_item(request: &CdpRequest, events: &EventSink) -> CdpReply {
+        let Some(storage_id) = request.params.get("storageId") else {
+            return CdpReply::error("removeDOMStorageItem requires storageId");
+        };
+        if !is_userdefaults_bucket(storage_id) {
+            return CdpReply::error("unknown storage bucket");
+        }
+        let Some(key) = request.params.get("key").and_then(Value::as_str) else {
+            return CdpReply::error("removeDOMStorageItem requires key");
+        };
+        // SAFETY: see get_dom_storage_items.
+        unsafe { remo_objc::delete_user_default(key) };
+        events.emit(
+            "DOMStorage.domStorageItemRemoved",
+            &json!({
+                "storageId": storage_id_json(),
+                "key": key,
+            }),
+        );
+        CdpReply::empty()
+    }
+
+    #[allow(unsafe_code)]
+    fn clear(request: &CdpRequest, events: &EventSink) -> CdpReply {
+        let Some(storage_id) = request.params.get("storageId") else {
+            return CdpReply::error("clear requires storageId");
+        };
+        if !is_userdefaults_bucket(storage_id) {
+            return CdpReply::error("unknown storage bucket");
+        }
+        // SAFETY: see get_dom_storage_items.
+        let entries = unsafe { remo_objc::list_user_defaults() };
+        // Deletes every key `list_user_defaults` reported. Note this can
+        // never actually bring the bucket to zero entries: that list reads
+        // `-dictionaryRepresentation`, which also surfaces NSGlobalDomain /
+        // `registerDefaults:` keys that aren't really in this app's own
+        // persistent domain, so `removeObjectForKey:` on them is a silent
+        // no-op — the same thing a real Chrome "clear site data" would find
+        // if it could clear NSGlobalDomain, which it can't. Not a bug in
+        // this method, just the ceiling of what "clear" can mean here.
+        // SAFETY: see get_dom_storage_items.
+        unsafe {
+            for (key, _) in &entries {
+                remo_objc::delete_user_default(key);
+            }
+        }
+        events.emit(
+            "DOMStorage.domStorageItemsCleared",
+            &json!({ "storageId": storage_id_json() }),
+        );
+        CdpReply::empty()
+    }
+
+    fn get_storage_key_for_frame(request: &CdpRequest) -> CdpReply {
+        // Frame ids: "1" is the main document (`domain_dom::MAIN_ORIGIN`),
+        // anything else is an origin string handed out verbatim as the
+        // child frame's own id (see domain_dom.rs's Page.getResourceTree).
+        let frame_id = request.params.get("frameId").and_then(Value::as_str);
+        let origin = match frame_id {
+            Some(id) if id == USERDEFAULTS_ORIGIN => USERDEFAULTS_ORIGIN,
+            _ => crate::domain_dom::MAIN_ORIGIN,
+        };
+        CdpReply::ok(json!({ "storageKey": storage_key(origin) }))
+    }
+}
+
+#[async_trait]
+impl CdpDomain for StorageDomain {
+    fn methods(&self) -> &'static [&'static str] {
+        &[
+            "DOMStorage.enable",
+            "DOMStorage.disable",
+            "DOMStorage.getDOMStorageItems",
+            "DOMStorage.setDOMStorageItem",
+            "DOMStorage.removeDOMStorageItem",
+            "DOMStorage.clear",
+            "Storage.getStorageKeyForFrame",
+            "Storage.setStorageBucketTracking",
+            "Storage.clearDataForOrigin",
+            "Storage.clearDataForStorageKey",
+        ]
+    }
+
+    async fn respond(&self, request: &CdpRequest, events: &EventSink) -> CdpReply {
+        match request.method.as_str() {
+            "DOMStorage.enable" | "DOMStorage.disable" => CdpReply::empty(),
+            "DOMStorage.getDOMStorageItems" => Self::get_dom_storage_items(request),
+            "DOMStorage.setDOMStorageItem" => Self::set_dom_storage_item(request, events),
+            "DOMStorage.removeDOMStorageItem" => Self::remove_dom_storage_item(request, events),
+            "DOMStorage.clear" => Self::clear(request, events),
+            "Storage.getStorageKeyForFrame" => Self::get_storage_key_for_frame(request),
+            // Acked, deliberately without a `Storage.storageBucketCreatedOrUpdated`
+            // event — see this module's doc comment on the IndexedDB/CacheStorage
+            // non-goal.
+            "Storage.setStorageBucketTracking" => CdpReply::empty(),
+            // "Clear site data" would mean wiping the one bucket we expose —
+            // fail loudly rather than silently doing nothing, matching the
+            // Swift reference.
+            "Storage.clearDataForOrigin" | "Storage.clearDataForStorageKey" => {
+                CdpReply::error("not supported — clear the storage bucket instead")
+            }
+            other => CdpReply::error(format!("Storage domain does not handle {other}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(method: &str, params: Value) -> CdpRequest {
+        CdpRequest {
+            id: 1,
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    fn assert_ok(reply: CdpReply) -> Value {
+        match reply {
+            CdpReply::Result(value) => value,
+            CdpReply::Error { message, .. } => panic!("expected Ok reply, got error: {message}"),
+        }
+    }
+
+    fn assert_err(reply: CdpReply) -> String {
+        match reply {
+            CdpReply::Result(value) => panic!("expected Error reply, got result: {value}"),
+            CdpReply::Error { message, .. } => message,
+        }
+    }
+
+    fn userdefaults_storage_id() -> Value {
+        json!({
+            "securityOrigin": USERDEFAULTS_ORIGIN,
+            "storageKey": format!("{USERDEFAULTS_ORIGIN}/"),
+            "isLocalStorage": true,
+        })
+    }
+
+    #[tokio::test]
+    async fn enable_and_disable_are_bare_acks() {
+        let domain = StorageDomain::new();
+        let (events, _rx) = EventSink::new();
+        for method in ["DOMStorage.enable", "DOMStorage.disable"] {
+            let reply = domain.respond(&request(method, json!({})), &events).await;
+            assert_eq!(assert_ok(reply), json!({}));
+        }
+    }
+
+    #[tokio::test]
+    async fn get_dom_storage_items_rejects_unknown_bucket() {
+        let domain = StorageDomain::new();
+        let (events, _rx) = EventSink::new();
+        let reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.getDOMStorageItems",
+                    json!({ "storageId": { "securityOrigin": "mmkv://whatever", "isLocalStorage": true } }),
+                ),
+                &events,
+            )
+            .await;
+        assert_err(reply);
+    }
+
+    #[tokio::test]
+    async fn get_dom_storage_items_returns_empty_entries_for_session_storage() {
+        let domain = StorageDomain::new();
+        let (events, _rx) = EventSink::new();
+        let mut storage_id = userdefaults_storage_id();
+        storage_id["isLocalStorage"] = json!(false);
+        let reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.getDOMStorageItems",
+                    json!({ "storageId": storage_id }),
+                ),
+                &events,
+            )
+            .await;
+        assert_eq!(assert_ok(reply), json!({ "entries": [] }));
+    }
+
+    #[tokio::test]
+    async fn get_dom_storage_items_accepts_security_origin_fallback() {
+        let domain = StorageDomain::new();
+        let (events, _rx) = EventSink::new();
+        let reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.getDOMStorageItems",
+                    json!({ "storageId": { "securityOrigin": USERDEFAULTS_ORIGIN, "isLocalStorage": true } }),
+                ),
+                &events,
+            )
+            .await;
+        let value = assert_ok(reply);
+        assert!(value.get("entries").unwrap().is_array());
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[tokio::test]
+    async fn set_then_get_round_trips_a_string() {
+        let domain = StorageDomain::new();
+        let (events, mut rx) = EventSink::new();
+        let key = "remo.cdp-tests.set_then_get_round_trips_a_string";
+        let set_reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.setDOMStorageItem",
+                    json!({ "storageId": userdefaults_storage_id(), "key": key, "value": "hello" }),
+                ),
+                &events,
+            )
+            .await;
+        assert_eq!(assert_ok(set_reply), json!({}));
+
+        let event = rx.try_recv().expect("expected domStorageItemAdded event");
+        assert_eq!(event["method"], "DOMStorage.domStorageItemAdded");
+        assert_eq!(event["params"]["key"], key);
+        assert_eq!(event["params"]["newValue"], "hello");
+
+        let get_reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.getDOMStorageItems",
+                    json!({ "storageId": userdefaults_storage_id() }),
+                ),
+                &events,
+            )
+            .await;
+        let entries = assert_ok(get_reply)["entries"].clone();
+        let entries = entries.as_array().unwrap();
+        assert!(entries.iter().any(|e| e == &json!([key, "hello"])));
+
+        // Clean up.
+        let _ = domain
+            .respond(
+                &request(
+                    "DOMStorage.removeDOMStorageItem",
+                    json!({ "storageId": userdefaults_storage_id(), "key": key }),
+                ),
+                &events,
+            )
+            .await;
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[tokio::test]
+    async fn non_string_values_round_trip_json_encoded() {
+        let domain = StorageDomain::new();
+        let (events, _rx) = EventSink::new();
+        let key = "remo.cdp-tests.non_string_values_round_trip_json_encoded";
+        let _ = domain
+            .respond(
+                &request(
+                    "DOMStorage.setDOMStorageItem",
+                    json!({ "storageId": userdefaults_storage_id(), "key": key, "value": "42" }),
+                ),
+                &events,
+            )
+            .await;
+        let get_reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.getDOMStorageItems",
+                    json!({ "storageId": userdefaults_storage_id() }),
+                ),
+                &events,
+            )
+            .await;
+        let entries = assert_ok(get_reply)["entries"].clone();
+        let entries = entries.as_array().unwrap();
+        // Written as the string "42", parsed as JSON number 42, displayed
+        // back as the text "42" — round-trips as a number under the hood,
+        // reads the same in the table either way.
+        assert!(entries.iter().any(|e| e == &json!([key, "42"])));
+
+        let _ = domain
+            .respond(
+                &request(
+                    "DOMStorage.removeDOMStorageItem",
+                    json!({ "storageId": userdefaults_storage_id(), "key": key }),
+                ),
+                &events,
+            )
+            .await;
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[tokio::test]
+    async fn remove_dom_storage_item_deletes_and_emits_event() {
+        let domain = StorageDomain::new();
+        let (events, mut rx) = EventSink::new();
+        let key = "remo.cdp-tests.remove_dom_storage_item_deletes_and_emits_event";
+        let _ = domain
+            .respond(
+                &request(
+                    "DOMStorage.setDOMStorageItem",
+                    json!({ "storageId": userdefaults_storage_id(), "key": key, "value": "x" }),
+                ),
+                &events,
+            )
+            .await;
+        let _ = rx.try_recv(); // drain the "added" event
+
+        let reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.removeDOMStorageItem",
+                    json!({ "storageId": userdefaults_storage_id(), "key": key }),
+                ),
+                &events,
+            )
+            .await;
+        assert_eq!(assert_ok(reply), json!({}));
+        let event = rx.try_recv().expect("expected domStorageItemRemoved event");
+        assert_eq!(event["method"], "DOMStorage.domStorageItemRemoved");
+        assert_eq!(event["params"]["key"], key);
+
+        let get_reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.getDOMStorageItems",
+                    json!({ "storageId": userdefaults_storage_id() }),
+                ),
+                &events,
+            )
+            .await;
+        let entries = assert_ok(get_reply)["entries"].clone();
+        let entries = entries.as_array().unwrap();
+        assert!(!entries.iter().any(|e| e[0] == key));
+    }
+
+    #[cfg(target_vendor = "apple")]
+    #[tokio::test]
+    async fn clear_removes_everything_and_emits_event() {
+        let domain = StorageDomain::new();
+        let (events, mut rx) = EventSink::new();
+        let key = "remo.cdp-tests.clear_removes_everything_and_emits_event";
+        let _ = domain
+            .respond(
+                &request(
+                    "DOMStorage.setDOMStorageItem",
+                    json!({ "storageId": userdefaults_storage_id(), "key": key, "value": "x" }),
+                ),
+                &events,
+            )
+            .await;
+        let _ = rx.try_recv(); // drain the "added" event
+
+        let reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.clear",
+                    json!({ "storageId": userdefaults_storage_id() }),
+                ),
+                &events,
+            )
+            .await;
+        assert_eq!(assert_ok(reply), json!({}));
+        let event = rx
+            .try_recv()
+            .expect("expected domStorageItemsCleared event");
+        assert_eq!(event["method"], "DOMStorage.domStorageItemsCleared");
+
+        let get_reply = domain
+            .respond(
+                &request(
+                    "DOMStorage.getDOMStorageItems",
+                    json!({ "storageId": userdefaults_storage_id() }),
+                ),
+                &events,
+            )
+            .await;
+        let entries = assert_ok(get_reply)["entries"].clone();
+        // Not asserting the list is *empty*: `list_user_defaults` reads
+        // `-dictionaryRepresentation`, which also surfaces NSGlobalDomain /
+        // `registerDefaults:` keys that `removeObjectForKey:` cannot
+        // actually remove (they're not really in this process's own
+        // persistent domain) — a real clear of a real app's defaults still
+        // leaves those behind. What matters is that our own test key, which
+        // *is* in the persistent domain, is gone.
+        assert!(!entries.as_array().unwrap().iter().any(|e| e[0] == key));
+    }
+
+    #[tokio::test]
+    async fn get_storage_key_for_frame_maps_main_and_userdefaults_frames() {
+        let domain = StorageDomain::new();
+        let (events, _rx) = EventSink::new();
+
+        let main_reply = domain
+            .respond(
+                &request("Storage.getStorageKeyForFrame", json!({ "frameId": "1" })),
+                &events,
+            )
+            .await;
+        assert_eq!(
+            assert_ok(main_reply)["storageKey"],
+            format!("{}/", crate::domain_dom::MAIN_ORIGIN)
+        );
+
+        let ud_reply = domain
+            .respond(
+                &request(
+                    "Storage.getStorageKeyForFrame",
+                    json!({ "frameId": USERDEFAULTS_ORIGIN }),
+                ),
+                &events,
+            )
+            .await;
+        assert_eq!(
+            assert_ok(ud_reply)["storageKey"],
+            format!("{USERDEFAULTS_ORIGIN}/")
+        );
+    }
+
+    #[tokio::test]
+    async fn set_storage_bucket_tracking_is_a_bare_ack() {
+        let domain = StorageDomain::new();
+        let (events, mut rx) = EventSink::new();
+        let reply = domain
+            .respond(
+                &request(
+                    "Storage.setStorageBucketTracking",
+                    json!({ "storageKey": format!("{}/", crate::domain_dom::MAIN_ORIGIN) }),
+                ),
+                &events,
+            )
+            .await;
+        assert_eq!(assert_ok(reply), json!({}));
+        assert!(
+            rx.try_recv().is_err(),
+            "must not emit storageBucketCreatedOrUpdated until IndexedDB/CacheStorage exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_data_for_origin_is_unsupported() {
+        let domain = StorageDomain::new();
+        let (events, _rx) = EventSink::new();
+        let reply = domain
+            .respond(&request("Storage.clearDataForOrigin", json!({})), &events)
+            .await;
+        assert_err(reply);
+    }
+
+    #[tokio::test]
+    async fn methods_list_matches_exactly_what_this_domain_claims() {
+        let domain = StorageDomain::new();
+        assert_eq!(
+            domain.methods(),
+            &[
+                "DOMStorage.enable",
+                "DOMStorage.disable",
+                "DOMStorage.getDOMStorageItems",
+                "DOMStorage.setDOMStorageItem",
+                "DOMStorage.removeDOMStorageItem",
+                "DOMStorage.clear",
+                "Storage.getStorageKeyForFrame",
+                "Storage.setStorageBucketTracking",
+                "Storage.clearDataForOrigin",
+                "Storage.clearDataForStorageKey",
+            ]
+        );
+    }
+}

--- a/crates/remo-cdp/src/lib.rs
+++ b/crates/remo-cdp/src/lib.rs
@@ -19,12 +19,15 @@
 //!   `Emulation` — Track B (real Chrome DevTools frontend compatibility).
 //! - [`domain_dom`] — `DOM`/`CSS`/`Overlay`: the UIView tree as an Elements
 //!   panel.
+//! - [`domain_storage`] — `DOMStorage`/`Storage`: `NSUserDefaults` as the
+//!   Application panel's Local Storage table.
 
 pub mod discovery;
 pub mod dispatcher;
 pub mod domain_dom;
 pub mod domain_page;
 pub mod domain_remo;
+pub mod domain_storage;
 pub mod dual_stack;
 pub mod remote_object;
 pub mod transport;

--- a/crates/remo-objc/Cargo.toml
+++ b/crates/remo-objc/Cargo.toml
@@ -20,6 +20,8 @@ objc2-foundation = { version = "0.3", features = [
     "NSUserDefaults", "NSData", "NSNull", "NSObjCRuntime", "NSPathUtilities",
 ] }
 objc2-ui-kit = { version = "0.3", features = ["UIView", "UIWindow", "UIApplication", "UIViewController", "UIResponder"], optional = true }
+security-framework = { version = "3", default-features = false }
+security-framework-sys = "2"
 
 [features]
 default = []

--- a/crates/remo-objc/Cargo.toml
+++ b/crates/remo-objc/Cargo.toml
@@ -29,6 +29,7 @@ objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = [
     "NSObject", "NSString", "NSArray", "NSDictionary", "NSValue",
     "NSUserDefaults", "NSData", "NSNull", "NSObjCRuntime", "NSPathUtilities",
+    "NSProcessInfo",
 ] }
 objc2-ui-kit = { version = "0.3", features = ["UIView", "UIWindow", "UIApplication", "UIViewController", "UIResponder"], optional = true }
 security-framework = { version = "3", default-features = false }

--- a/crates/remo-objc/Cargo.toml
+++ b/crates/remo-objc/Cargo.toml
@@ -8,9 +8,20 @@ workspace = true
 
 [dependencies]
 serde.workspace = true
-serde_json.workspace = true
 tracing.workspace = true
 base64.workspace = true
+# `unbounded_depth` is required for `Deserializer::disable_recursion_limit`,
+# used by `swiftui_debug.rs` (see its `serde_stacker` dependency below) —
+# real SwiftUI debug-data payloads nest past serde_json's default limit.
+serde_json = { workspace = true, features = ["unbounded_depth"] }
+# Real SwiftUI debug-data payloads (crates/remo-objc/src/swiftui_debug.rs)
+# nest well past serde_json's default 128-level recursion limit — confirmed
+# empirically against the demo app (iOS 26.2 simulator): a real hosting
+# view's JSON blew the default limit around 50-80KB into a ~300KB payload.
+# `serde_stacker` pairs `disable_recursion_limit()` with growing the actual
+# OS thread stack on demand, so deep-but-legitimate trees parse instead of
+# either erroring out or risking a real stack overflow.
+serde_stacker = "0.1"
 
 # objc2 ecosystem — only compiled on Apple targets.
 [target.'cfg(target_vendor = "apple")'.dependencies]

--- a/crates/remo-objc/src/keychain.rs
+++ b/crates/remo-objc/src/keychain.rs
@@ -1,0 +1,220 @@
+//! Keychain generic-password access — real credential-store debugging,
+//! generic to any iOS (or macOS) app, not something an app has to register a
+//! capability for itself. Mirrors `user_defaults.rs`'s shape: `list`/`get`/
+//! `set`/`delete` over a single storage domain, keyed here by `(service,
+//! account)` rather than a single string key, since that's how
+//! `kSecClassGenericPassword` items are actually identified.
+//!
+//! Unlike `NSUserDefaults`, the Keychain has no bulk "give me every value"
+//! call — listing means searching for every `kSecClassGenericPassword` item
+//! with attributes loaded, which only yields metadata (service/account/label/
+//! ...), not the secret data itself (that needs a second, targeted query per
+//! item, which `list` deliberately avoids doing automatically — see `list`'s
+//! doc comment).
+
+use serde_json::Value;
+
+#[cfg(target_vendor = "apple")]
+mod apple {
+    use super::*;
+    use security_framework::item::{ItemClass, ItemSearchOptions, Limit, SearchResult};
+    use security_framework::passwords::{
+        delete_generic_password, get_generic_password, set_generic_password,
+    };
+
+    /// Every generic-password item currently in the keychain, as attribute
+    /// maps (service/account/label/... — whatever Security.framework
+    /// reports). Deliberately does not include the secret value: bulk-reading
+    /// every password's plaintext just to list what exists is a needless
+    /// blast radius `get` (given a specific service/account) already covers.
+    pub fn list() -> Result<Vec<Value>, String> {
+        let results = ItemSearchOptions::new()
+            .class(ItemClass::generic_password())
+            .load_attributes(true)
+            .limit(Limit::All)
+            .search();
+        let results = match results {
+            Ok(results) => results,
+            // errSecItemNotFound just means an empty keychain domain, not a
+            // real failure — same as user_defaults::list returning empty.
+            Err(e) if e.code() == security_framework_sys::base::errSecItemNotFound => {
+                return Ok(Vec::new())
+            }
+            Err(e) => return Err(e.to_string()),
+        };
+        Ok(results
+            .iter()
+            .filter_map(SearchResult::simplify_dict)
+            .map(|attrs| {
+                let map: serde_json::Map<String, Value> = attrs
+                    .into_iter()
+                    .map(|(k, v)| (k, Value::String(v)))
+                    .collect();
+                Value::Object(map)
+            })
+            .collect())
+    }
+
+    /// The password bytes for `service`/`account`, or `None` if no such item
+    /// exists. Returned as a UTF-8 string when valid, else base64 — most
+    /// generic passwords are text, but the Keychain doesn't guarantee it.
+    pub fn get(service: &str, account: &str) -> Result<Option<Value>, String> {
+        match get_generic_password(service, account) {
+            Ok(bytes) => Ok(Some(bytes_to_json(&bytes))),
+            Err(e) if e.code() == security_framework_sys::base::errSecItemNotFound => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    /// Sets (creating or overwriting) the password for `service`/`account`.
+    pub fn set(service: &str, account: &str, password: &str) -> Result<(), String> {
+        set_generic_password(service, account, password.as_bytes()).map_err(|e| e.to_string())
+    }
+
+    /// Deletes the item for `service`/`account`. A missing item is not an
+    /// error — matches `userDefaults.delete`'s "already gone is fine" shape.
+    pub fn delete(service: &str, account: &str) -> Result<(), String> {
+        match delete_generic_password(service, account) {
+            Ok(()) => Ok(()),
+            Err(e) if e.code() == security_framework_sys::base::errSecItemNotFound => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    fn bytes_to_json(bytes: &[u8]) -> Value {
+        match std::str::from_utf8(bytes) {
+            Ok(s) => Value::String(s.to_string()),
+            Err(_) => {
+                use base64::Engine;
+                Value::String(base64::engine::general_purpose::STANDARD.encode(bytes))
+            }
+        }
+    }
+}
+
+#[cfg(not(target_vendor = "apple"))]
+mod apple {
+    use super::*;
+
+    pub fn list() -> Result<Vec<Value>, String> {
+        tracing::warn!("keychain::list called on non-Apple target, returning empty");
+        Ok(Vec::new())
+    }
+
+    pub fn get(_service: &str, _account: &str) -> Result<Option<Value>, String> {
+        tracing::warn!("keychain::get called on non-Apple target, returning None");
+        Ok(None)
+    }
+
+    pub fn set(_service: &str, _account: &str, _password: &str) -> Result<(), String> {
+        tracing::warn!("keychain::set called on non-Apple target, no-op");
+        Ok(())
+    }
+
+    pub fn delete(_service: &str, _account: &str) -> Result<(), String> {
+        tracing::warn!("keychain::delete called on non-Apple target, no-op");
+        Ok(())
+    }
+}
+
+/// Attribute maps for every generic-password keychain item — see
+/// [`apple::list`] for why secret values are never included in bulk.
+pub fn list_keychain_items() -> Result<Vec<Value>, String> {
+    apple::list()
+}
+
+/// The password for `service`/`account`, or `None` if no such item exists.
+pub fn get_keychain_item(service: &str, account: &str) -> Result<Option<Value>, String> {
+    apple::get(service, account)
+}
+
+/// Sets (creating or overwriting) the password for `service`/`account`.
+pub fn set_keychain_item(service: &str, account: &str, password: &str) -> Result<(), String> {
+    apple::set(service, account, password)
+}
+
+/// Removes the item for `service`/`account`, if present.
+pub fn delete_keychain_item(service: &str, account: &str) -> Result<(), String> {
+    apple::delete(service, account)
+}
+
+#[cfg(all(test, target_vendor = "apple"))]
+mod tests {
+    //! Runs against this machine's *real* keychain — Security.framework
+    //! needs no iOS simulator/device to exercise for real, same reasoning as
+    //! `user_defaults.rs`'s tests. Every item is distinctly prefixed and
+    //! cleaned up so a test run never leaves stray state behind.
+    use super::*;
+
+    fn test_service(name: &str) -> String {
+        format!("remo.remo-objc-tests.{name}")
+    }
+
+    #[test]
+    fn string_round_trips() {
+        let service = test_service("string_round_trips");
+        set_keychain_item(&service, "acct", "hello").unwrap();
+        assert_eq!(
+            get_keychain_item(&service, "acct").unwrap(),
+            Some(Value::String("hello".to_string()))
+        );
+        delete_keychain_item(&service, "acct").unwrap();
+        assert_eq!(get_keychain_item(&service, "acct").unwrap(), None);
+    }
+
+    #[test]
+    fn set_then_set_again_overwrites_not_duplicates() {
+        let service = test_service("set_then_set_again_overwrites_not_duplicates");
+        set_keychain_item(&service, "acct", "first").unwrap();
+        set_keychain_item(&service, "acct", "second").unwrap();
+        assert_eq!(
+            get_keychain_item(&service, "acct").unwrap(),
+            Some(Value::String("second".to_string()))
+        );
+        delete_keychain_item(&service, "acct").unwrap();
+    }
+
+    #[test]
+    fn delete_then_get_is_none() {
+        let service = test_service("delete_then_get_is_none");
+        set_keychain_item(&service, "acct", "temp").unwrap();
+        delete_keychain_item(&service, "acct").unwrap();
+        assert_eq!(get_keychain_item(&service, "acct").unwrap(), None);
+    }
+
+    #[test]
+    fn delete_of_missing_item_is_not_an_error() {
+        let service = test_service("delete_of_missing_item_is_not_an_error");
+        delete_keychain_item(&service, "acct").unwrap();
+    }
+
+    #[test]
+    fn list_includes_a_freshly_set_item() {
+        let service = test_service("list_includes_a_freshly_set_item");
+        set_keychain_item(&service, "acct", "visible").unwrap();
+
+        // securityd serializes concurrent keychain access across the whole
+        // test binary, so a `kSecMatchLimitAll` search running alongside
+        // other tests' own adds/deletes can occasionally observe a
+        // transient snapshot that hasn't caught up yet — retry briefly
+        // rather than flake. `string_round_trips`/etc. don't need this
+        // because get/delete target one exact item, not a full-table scan.
+        let mut found = false;
+        for _ in 0..20 {
+            let all = list_keychain_items().unwrap();
+            found = all.iter().any(|item| {
+                item.get("svce")
+                    .and_then(Value::as_str)
+                    .map(|s| s == service)
+                    .unwrap_or(false)
+            });
+            if found {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        assert!(found, "expected {service} to appear in keychain.list");
+
+        delete_keychain_item(&service, "acct").unwrap();
+    }
+}

--- a/crates/remo-objc/src/lib.rs
+++ b/crates/remo-objc/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod device_info;
 pub mod filesystem;
+pub mod keychain;
 pub mod main_thread;
 pub mod screen_capture;
 pub mod screenshot;
@@ -11,6 +12,9 @@ pub mod view_tree;
 
 pub use device_info::{get_app_info, get_device_info, AppInfo, DeviceInfo};
 pub use filesystem::{delete_path, home_directory, list_directory, read_file, FileEntry};
+pub use keychain::{
+    delete_keychain_item, get_keychain_item, list_keychain_items, set_keychain_item,
+};
 pub use main_thread::{is_main_thread, run_on_main_sync};
 pub use screen_capture::{capture_frame_to_pixel_buffer, get_screen_info, CaptureInfo};
 pub use screenshot::{capture_screenshot, ScreenshotResult};

--- a/crates/remo-objc/src/lib.rs
+++ b/crates/remo-objc/src/lib.rs
@@ -6,6 +6,7 @@ pub mod keychain;
 pub mod main_thread;
 pub mod screen_capture;
 pub mod screenshot;
+pub mod swiftui_debug;
 pub mod user_defaults;
 pub mod video_encoder;
 pub mod view_tree;

--- a/crates/remo-objc/src/swiftui_debug.rs
+++ b/crates/remo-objc/src/swiftui_debug.rs
@@ -452,8 +452,10 @@ fn parse_json_deeply_nested(bytes: &[u8]) -> serde_json::Result<serde_json::Valu
 }
 
 fn decode_json_nodes(value: &serde_json::Value) -> Option<Vec<ViewNode>> {
+    reset_filter_counters();
     let array = value.as_array()?;
     let nodes: Vec<ViewNode> = array.iter().filter_map(decode_json_node).collect();
+    log_filter_summary();
     if nodes.is_empty() {
         None
     } else {
@@ -545,8 +547,23 @@ fn decode_json_node(value: &serde_json::Value) -> Option<ViewNode> {
     // Elements panel displays as the tag name) produced unreadable
     // multi-hundred-character tags. `domain_dom.rs`'s `attributes()`
     // surfaces `modifiers` as its own CDP attribute instead.
+    //
+    // That alone isn't enough, though: a `flags:1` type string can *itself*
+    // be a `ModifiedContent<Base, Modifier>` — SwiftUI's own type system
+    // nests modifiers into the type, not just this payload's separate
+    // `flags:2` properties. Confirmed against a real captured node in this
+    // demo app: a 3018-character `readableType` that was
+    // `ModifiedContent<ModifiedContent<NavigationStackStyledCore<...>, ...>,
+    // ...>` — no sibling `flags:2` property to split off at all, so the
+    // step-1 fix alone left it untouched. `unwrap_modified_content` peels
+    // that apart the same way, recursively, before it ever becomes
+    // `class_name`.
     let class_name = match &type_name {
-        Some(t) => t.clone(),
+        Some(t) => {
+            let (base, peeled) = unwrap_modified_content(t);
+            modifiers.extend(peeled);
+            base
+        }
         // The "only a modifier, no view type" case still needs *some*
         // label — synthesize one from the modifier list rather than an
         // empty tag name (and don't also duplicate it into `modifiers`,
@@ -563,12 +580,37 @@ fn decode_json_node(value: &serde_json::Value) -> Option<ViewNode> {
     } else {
         Vec::new()
     };
+    // Defensive cap, independent of the `ModifiedContent`-unwrapping above:
+    // the *base* type left after unwrapping can still be enormous on its
+    // own (that same real 3018-char node's base, after peeling 2 modifiers,
+    // was `NavigationStackStyledCore<...>` wrapping a whole `VStack` tree —
+    // still thousands of characters). This isn't
+    // `LKS_SwiftUICompactFilter`-grade structural recognition for every
+    // container shape (out of scope for this pass); it's a hard length
+    // limit so nothing ever reaches a tag name in the thousands of
+    // characters again, full stop.
+    let class_name = cap_display_length(&class_name, MAX_CLASS_NAME_CHARS);
 
-    let children = value
+    // Bounded properties flattener (independent of the tag-name logic
+    // above) — walks this node's full attribute tree, including nested
+    // `subattributes`, into flat rows for `domain_dom.rs`'s
+    // `CSS.getComputedStyleForNode` pseudo-CSS mapping. See
+    // `flatten_node_properties`'s doc comment for the depth/row limits and
+    // truncation behavior.
+    let style_rows = flatten_node_properties(properties, FLATTEN_DEPTH_LIMIT, FLATTEN_ROW_CAP);
+
+    let raw_children: Vec<ViewNode> = value
         .get("children")
         .and_then(serde_json::Value::as_array)
         .map(|kids| kids.iter().filter_map(decode_json_node).collect())
         .unwrap_or_default();
+    // Node-hiding filter (see `classify`'s doc comment) — applied here,
+    // one level up from where each child was itself decoded, so an
+    // `ElideHoist` decision can splice that child's own (already
+    // bottom-up-filtered) children directly into *this* node's child list.
+    let children = apply_view_filter(raw_children);
+
+    count_decoded_node();
 
     Some(ViewNode {
         class_name,
@@ -583,8 +625,317 @@ fn decode_json_node(value: &serde_json::Value) -> Option<ViewNode> {
         tag: 0,
         accessibility_id: None,
         modifiers,
+        style_rows,
         children,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Part A — recursive `ModifiedContent<Base, Modifier>` unwrapping for the
+// tag name, and a hard length cap as the last line of defense.
+// ---------------------------------------------------------------------------
+
+/// Hard cap on `class_name`'s displayed length, applied after
+/// `ModifiedContent` unwrapping. Not a structural-recognition attempt at
+/// every possible huge container shape (`TupleView<(A, B, C, ...)>` and
+/// friends can still be long) — just a safety net so nothing this deep ever
+/// produces a tag name in the thousands of characters again. Starting
+/// point, not a carefully-tuned exact value; adjust if real payloads
+/// suggest a different number reads better in practice.
+const MAX_CLASS_NAME_CHARS: usize = 200;
+
+/// Truncates `s` to at most `max_chars` *characters* (not bytes — these
+/// strings are printable ASCII in every payload seen so far, but char-safe
+/// truncation costs nothing and avoids ever panicking on a multi-byte
+/// boundary), appending `…` when truncation actually happened.
+fn cap_display_length(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let mut truncated: String = s.chars().take(max_chars).collect();
+    truncated.push('…');
+    truncated
+}
+
+/// Recursively peels `ModifiedContent<Base, Modifier>` off a SwiftUI type
+/// string, the way SwiftUI's own type system nests a view's applied
+/// modifiers *into its type* — a `flags:2` property is a separate, sibling
+/// way modifiers show up in this payload, but this is the other one, and
+/// nothing about the payload's `properties` array signals it; it only shows
+/// up by pattern-matching the type string itself.
+///
+/// Returns `(base_type, peeled_modifiers)` where `peeled_modifiers` is
+/// ordered outermost-first (the modifier applied last, textually the
+/// outermost wrapper, comes first) — an arbitrary but documented choice;
+/// nothing currently depends on the order.
+///
+/// Stops as soon as the outermost shape no longer parses as
+/// `ModifiedContent<X, Y>` (including: wrong number of top-level generic
+/// arguments, which a real `ModifiedContent` should never have but a
+/// different, unanticipated shape might) — never guesses past what it can
+/// actually parse.
+fn unwrap_modified_content(type_str: &str) -> (String, Vec<String>) {
+    let mut current = type_str.trim().to_string();
+    let mut modifiers = Vec::new();
+    loop {
+        let Some((name, mut args)) = parse_outer_generic(&current) else {
+            break;
+        };
+        if !is_modified_content(name) || args.len() != 2 {
+            break;
+        }
+        // `args` is [Base, Modifier] in source order.
+        let modifier = args.remove(1);
+        let base = args.remove(0);
+        modifiers.push(modifier.trim().to_string());
+        current = base.trim().to_string();
+    }
+    (current, modifiers)
+}
+
+/// Whether `name` (the part of a type string before its first top-level
+/// `<`) refers to `ModifiedContent`, tolerating a module-qualified form
+/// (`SwiftUI.ModifiedContent`) — `readableType` strings seen so far never
+/// carry the module prefix, but `type` (fully-qualified) always does, and
+/// nothing guarantees which one this function is ever called with.
+fn is_modified_content(name: &str) -> bool {
+    name == "ModifiedContent" || name.ends_with(".ModifiedContent")
+}
+
+/// Parses `Name<Arg1, Arg2, ...>` into `(Name, [Arg1, Arg2, ...])`, splitting
+/// only on *top-level* commas — i.e. not commas nested inside another
+/// `<...>` generic or a `(...)` tuple type (SwiftUI type strings routinely
+/// contain both, e.g. `TupleView<(Text, Image)>`). Returns `None` if `s`
+/// doesn't have this shape at all, or if the generic argument list isn't
+/// properly balanced (defensive against a future payload format this
+/// wasn't written against — never panics on malformed input).
+fn parse_outer_generic(s: &str) -> Option<(&str, Vec<&str>)> {
+    let open = s.find('<')?;
+    // The whole string must be exactly `Name<...>` — if there's anything
+    // after the matching close bracket, this isn't a single bare generic
+    // type (could be a tuple element list, a qualified member reference
+    // like `Foo<Bar>.Baz`, etc.) and guessing which part to unwrap would
+    // risk silently mangling something this wasn't verified against.
+    let close = matching_close_angle_bracket(s, open)?;
+    if close != s.len() - 1 {
+        return None;
+    }
+    let name = &s[..open];
+    if name.is_empty() {
+        return None;
+    }
+    let inner = &s[open + 1..close];
+    Some((name, split_top_level_commas(inner)))
+}
+
+/// Finds the index of the `>` that closes the `<` at byte index `open`,
+/// tracking nesting depth across `<>`, `()`, and `[]` (SwiftUI type strings
+/// use tuple parens; brackets aren't known to appear, but costs nothing to
+/// track defensively). Returns `None` if the brackets never balance.
+fn matching_close_angle_bracket(s: &str, open: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    debug_assert_eq!(bytes.get(open), Some(&b'<'));
+    let mut depth: i32 = 0;
+    for (i, &b) in bytes.iter().enumerate().skip(open) {
+        match b {
+            b'<' | b'(' | b'[' => depth += 1,
+            b'>' | b')' | b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Splits `s` on top-level commas only — depth-tracked across `<>`, `()`,
+/// and `[]` the same way `matching_close_angle_bracket` is, so a comma
+/// inside a nested generic or tuple never causes a false split.
+fn split_top_level_commas(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut parts = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0usize;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'<' | b'(' | b'[' => depth += 1,
+            b'>' | b')' | b']' => depth -= 1,
+            b',' if depth == 0 => {
+                parts.push(s[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(s[start..].trim());
+    parts
+}
+
+// ---------------------------------------------------------------------------
+// Part B — bounded properties flattener, feeding the pseudo-CSS surface.
+// ---------------------------------------------------------------------------
+
+/// Starting points for the flattener's bounds, not carefully-tuned exact
+/// requirements — matching LookInside's own `SwiftUIAttributeFlattener`
+/// signature (`depthLimit`/`rowCap`), reverse-engineered from its binary
+/// symbols, which takes these as *parameters* rather than fixed constants.
+/// Kept as plain constants here since nothing today calls this with a
+/// different value, but nothing structurally prevents it either.
+const FLATTEN_DEPTH_LIMIT: usize = 8;
+const FLATTEN_ROW_CAP: usize = 50;
+/// Per-row title/value length cap — the same class of problem
+/// `MAX_CLASS_NAME_CHARS` guards against (a deeply-nested-generic type
+/// string used verbatim), just applied to properties-panel rows instead of
+/// the tag name. Confirmed necessary live: without this, a `flags:1`
+/// attribute with no `name_hint`, no scalar value, and no subattributes
+/// produces a row whose title *and* value are both its own (potentially
+/// thousands-of-characters) type string.
+const FLATTEN_ROW_TEXT_CHAR_LIMIT: usize = 150;
+
+/// Flattens every property on a node — its `flags:0`/`1`/`2` attributes and
+/// their nested `subattributes`, recursively — into a flat list of
+/// `(title, value)` rows suitable for a CDP pseudo-CSS declaration list.
+/// Not exact Swift-call-syntax reconstruction (no attempt at rendering
+/// `.font(.title3)`); LookInside's own `jsonValueToString`/`compactJSON`
+/// symbols don't do that either, just readable stringification, so this
+/// doesn't try to clear a bar the reference implementation itself doesn't
+/// clear.
+///
+/// Bounded on two axes, matching `SwiftUIAttributeFlattener.flatten`'s
+/// signature: `depth_limit` caps how far into nested `subattributes` this
+/// recurses, `row_cap` caps the total number of rows produced across the
+/// whole node. When either limit stops the walk from descending into or
+/// including something, a trailing `("…", "N more (truncated)")` row is
+/// appended so the cut-off is visible in the CDP reply rather than a
+/// silent drop — matching the spirit (not the exact wording) of the
+/// `" more (truncated)"` string confirmed via `strings` against the real
+/// `LookInsideServer.xcframework` binary.
+fn flatten_node_properties(
+    properties: &[serde_json::Value],
+    depth_limit: usize,
+    row_cap: usize,
+) -> Vec<(String, String)> {
+    let mut rows = Vec::new();
+    let mut skipped = 0usize;
+    for prop in properties {
+        if let Some(attribute) = prop.get("attribute") {
+            flatten_attribute(
+                attribute,
+                None,
+                0,
+                depth_limit,
+                row_cap,
+                &mut rows,
+                &mut skipped,
+            );
+        }
+    }
+    if skipped > 0 {
+        rows.push(("…".to_string(), format!("{skipped} more (truncated)")));
+    }
+    rows
+}
+
+/// One step of the flattener's recursion. `name_hint` is the title to use
+/// when the caller already knows it (a `subattributes` entry's own
+/// `"name"`, e.g. `"searchAdjustment"`); falls back to the attribute's own
+/// type name (`attribute_text`) when there is none (true for every
+/// top-level `flags:0/1/2` property, which don't carry a `"name"`).
+///
+/// A node beyond `depth_limit`, or once `row_cap` rows have already been
+/// produced, is counted in `skipped` and *not* recursed into further —
+/// deliberately not attempting an exact remaining-row count (which would
+/// mean walking the rest of the tree anyway, defeating the point of a
+/// bound), just a visible "something was cut off here" signal.
+#[allow(clippy::too_many_arguments)]
+fn flatten_attribute(
+    attribute: &serde_json::Value,
+    name_hint: Option<&str>,
+    depth: usize,
+    depth_limit: usize,
+    row_cap: usize,
+    rows: &mut Vec<(String, String)>,
+    skipped: &mut usize,
+) {
+    if depth > depth_limit || rows.len() >= row_cap {
+        *skipped += 1;
+        return;
+    }
+    // Same hard cap as `class_name` (Part A), and for the same reason: a
+    // top-level `flags:1`/`flags:2` attribute's own type name is exactly
+    // the kind of deeply-nested-generic string that can be thousands of
+    // characters, and here it's used verbatim as both a row's *title* (with
+    // no `name_hint` to fall back on) and, in the no-value/no-subattributes
+    // branch below, its *value* too — a `--swiftui-<huge string>` custom
+    // property would just be the same tag-name problem restated inside the
+    // Styles pane instead of fixed. Unlike `class_name`, this is not run
+    // through `unwrap_modified_content` first (these rows are meant to be
+    // short, readable labels, not a second place asserting exact SwiftUI
+    // type-parsing correctness) — the flat length cap alone is enough here.
+    let title = cap_display_length(
+        &name_hint
+            .map(str::to_string)
+            .or_else(|| attribute_text(attribute))
+            .unwrap_or_else(|| "?".to_string()),
+        FLATTEN_ROW_TEXT_CHAR_LIMIT,
+    );
+
+    let scalar_value = attribute
+        .get("value")
+        .filter(|v| !v.is_null())
+        .map(stringify_attribute_value);
+    let subattributes = attribute
+        .get("subattributes")
+        .and_then(serde_json::Value::as_array)
+        .filter(|subs| !subs.is_empty());
+
+    match (scalar_value, subattributes) {
+        (Some(value), _) => rows.push((
+            title,
+            cap_display_length(&value, FLATTEN_ROW_TEXT_CHAR_LIMIT),
+        )),
+        (None, Some(subs)) => {
+            for sub in subs {
+                let sub_name = sub.get("name").and_then(serde_json::Value::as_str);
+                flatten_attribute(
+                    sub,
+                    sub_name,
+                    depth + 1,
+                    depth_limit,
+                    row_cap,
+                    rows,
+                    skipped,
+                );
+            }
+        }
+        // Nothing scalar and nothing to recurse into — still informative
+        // to show that this property exists, using its own type as the
+        // value (e.g. a modifier with a genuinely empty payload under the
+        // safe env-var path, matching the "modifier payloads are often
+        // null" caveat this module already documents elsewhere).
+        (None, None) => {
+            if let Some(t) = attribute_text(attribute) {
+                rows.push((title, cap_display_length(&t, FLATTEN_ROW_TEXT_CHAR_LIMIT)));
+            }
+        }
+    }
+}
+
+/// Stringifies a JSON value for display — matching LookInside's own
+/// `jsonValueToString`/`compactJSON` bar (readable stringification), not
+/// exact Swift-syntax reconstruction. Scalars render as their natural text
+/// form; objects/arrays render as compact JSON.
+fn stringify_attribute_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
 }
 
 /// Prefers `attribute.readableType` (short, human-facing) over
@@ -597,6 +948,226 @@ fn attribute_text(attribute: &serde_json::Value) -> Option<String> {
         }
     }
     None
+}
+
+// ---------------------------------------------------------------------------
+// Node-hiding filter — collapses purely-structural SwiftUI plumbing nodes
+// (never real user content) out of the tree.
+// ---------------------------------------------------------------------------
+//
+// Mirrors the *shape* of `LKS_SwiftUIFilterDecision` from the real
+// `LookInsideServer.xcframework` binary, confirmed via `nm -a | swift
+// demangle`:
+//
+//   enum LKS_SwiftUIFilterDecision: Equatable {
+//       case keep
+//       case elideHoist     // remove this node; splice its children up
+//       case elideSubviews  // keep this node, discard its children
+//       case mergeInto(String)
+//   }
+//
+// backed there by (at least) `isTransparentGenericStackWrapper` and
+// `isColorBackedByColorView` — `nm`/reflection only gives their *signatures*,
+// never their bodies, so `classify` below is this crate's own independently
+// reasoned heuristic, not a port of theirs. It is also deliberately more
+// conservative than what the signatures alone might suggest: the real
+// predicates apparently also weigh geometry (`containsProjectedStackLayout`
+// looks like it avoids eliding a wrapper that would destroy a stack
+// layout's frame information further down) — this crate's SwiftUI nodes all
+// report a zero frame today (a documented, separate gap — see
+// `decode_json_node`'s flags:0 handling above), so geometry is not an
+// available signal here and isn't used as one. Where the real
+// implementation might have geometry to lean on, this one leans on a
+// narrower, exact-match type-name allowlist instead, on the theory that
+// under-eliding (a few extra harmless wrapper nodes stay visible) is a far
+// safer failure mode for a debugging tool than over-eliding (hiding real
+// content).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FilterDecision {
+    Keep,
+    /// Remove this node; splice its children directly into its parent's
+    /// position instead.
+    ElideHoist,
+    /// Keep this node itself, but discard its children (they're known
+    /// internal plumbing, not user content).
+    ElideSubviews,
+    /// Fold this node's info into a named ancestor group instead of
+    /// emitting it as a separate tree node. Never actually produced by
+    /// `classify` in this pass — Part B's properties flattener already
+    /// folds a node's *own* modifier/attribute detail into `style_rows`,
+    /// which covers the cases this crate has evidence for; merging a whole
+    /// *separate sibling node's* identity into an ancestor is a different,
+    /// riskier operation with no real captured payload to justify a
+    /// specific heuristic for yet. Kept only so the enum's shape matches
+    /// the real one — nothing constructs this variant today.
+    #[allow(dead_code)]
+    MergeInto(String),
+}
+
+/// Type-name prefixes recognized as purely-structural SwiftUI plumbing that
+/// contributes no visual/semantic identity of its own — candidates for
+/// `ElideHoist`, and *only* candidates: `classify` additionally requires
+/// exactly one child and no modifiers of the wrapper's own before actually
+/// eliding one (see its doc comment for why name-matching alone isn't
+/// enough). Deliberately excludes real layout containers
+/// (`VStack`/`HStack`/`ZStack`/`List`/`ScrollView`/...) even though some of
+/// them can also appear with a single child — those are genuine content
+/// containers a user would recognize and want to see, not implementation
+/// plumbing, so they're never candidates here regardless of child count.
+const TRANSPARENT_WRAPPER_PREFIXES: &[&str] = &[
+    "_VariadicView.Tree<",
+    "_VariadicView_Children",
+    "TupleView<",
+    "_ConditionalContent<",
+    "_UnaryViewAdaptor<",
+    "LazyView<",
+    "PlaceholderContentView<",
+    "AnyView",
+];
+
+/// Exact base type names (the part of `class_name` before any generic `<`)
+/// recognized as known leaf SwiftUI primitives — candidates for
+/// `ElideSubviews`. Exact-match, not prefix/substring match, specifically
+/// so this can never accidentally fire on an unrelated type that merely
+/// starts with, say, `"Color"` (`ColorPicker`, a real interactive control a
+/// user would want to see, is not `"Color"`).
+const LEAF_PRIMITIVE_BASE_NAMES: &[&str] = &["Color", "Spacer", "Divider", "EmptyView"];
+
+/// Classifies one already-decoded (and already recursively filtered —
+/// `children` here reflects this node's own children *after* their own
+/// level's filtering already ran) `ViewNode` for the node-hiding filter.
+///
+/// `ElideSubviews` is checked first and doesn't require an empty
+/// `modifiers` list — hiding a `Color`/`Spacer`/etc.'s internal-plumbing
+/// children is safe regardless of whether a modifier was applied to the
+/// primitive itself (that modifier detail is unaffected; it's still on
+/// this node, which stays in the tree). `ElideHoist` is stricter: it
+/// removes the node entirely, so it additionally requires the wrapper to
+/// carry no modifiers of its own (losing modifier detail by silently
+/// deleting the node that carried it would be exactly the kind of
+/// information loss this filter must not cause) and exactly one child
+/// (hoisting a multi-child wrapper would ambiguously reparent siblings that
+/// were never siblings in the real view tree).
+fn classify(node: &ViewNode) -> FilterDecision {
+    let base_name = node
+        .class_name
+        .split('<')
+        .next()
+        .unwrap_or(&node.class_name);
+
+    if LEAF_PRIMITIVE_BASE_NAMES.contains(&base_name) && !node.children.is_empty() {
+        return FilterDecision::ElideSubviews;
+    }
+
+    if node.modifiers.is_empty()
+        && node.children.len() == 1
+        && TRANSPARENT_WRAPPER_PREFIXES
+            .iter()
+            .any(|prefix| node.class_name.starts_with(prefix))
+    {
+        return FilterDecision::ElideHoist;
+    }
+
+    FilterDecision::Keep
+}
+
+/// Escape hatch for A/B comparison and rollback without a rebuild — set to
+/// disable the filter entirely and get the pre-filter tree back, e.g. to
+/// confirm a specific node's disappearance is actually this filter's doing.
+fn filter_disabled() -> bool {
+    std::env::var_os("SWIFTUI_DEBUG_DISABLE_NODE_FILTER").is_some()
+}
+
+/// Applies `classify` to one node's already-decoded children, producing the
+/// filtered child list actually attached to the `ViewNode` being built.
+fn apply_view_filter(children: Vec<ViewNode>) -> Vec<ViewNode> {
+    apply_view_filter_with(children, filter_disabled())
+}
+
+/// The actual filtering logic, taking `disabled` as a plain argument rather
+/// than reading the env var itself — specifically so tests can exercise the
+/// disabled path directly rather than mutating process-global env state
+/// (`std::env::set_var` in one `#[test]` racing another's `filter_disabled()`
+/// read, since Rust test binaries run tests concurrently by default).
+fn apply_view_filter_with(children: Vec<ViewNode>, disabled: bool) -> Vec<ViewNode> {
+    if disabled {
+        return children;
+    }
+    let mut result = Vec::with_capacity(children.len());
+    for child in children {
+        match classify(&child) {
+            FilterDecision::Keep => {
+                FILTER_KEPT_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                result.push(child);
+            }
+            FilterDecision::ElideHoist => {
+                FILTER_ELIDE_HOIST_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                result.extend(child.children);
+            }
+            FilterDecision::ElideSubviews => {
+                FILTER_ELIDE_SUBVIEWS_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let mut kept = child;
+                kept.children.clear();
+                result.push(kept);
+            }
+            FilterDecision::MergeInto(_) => {
+                // Never actually produced by `classify` today — see its
+                // doc comment — but handled for completeness rather than
+                // left as an unreachable match arm, in case that changes.
+                FILTER_MERGE_INTO_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                result.push(child);
+            }
+        }
+    }
+    result
+}
+
+/// Per-`DOM.getDocument`-call (really: per hosting view — see
+/// `decode_json_nodes`, the only caller of `reset_filter_counters`/
+/// `log_filter_summary`) counters, so the filter's effect is directly
+/// observable via tracing rather than only inferable from tree-size
+/// differences. `Relaxed` throughout: these are diagnostic counters, not
+/// synchronization.
+static DECODED_NODE_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static FILTER_KEPT_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+static FILTER_ELIDE_HOIST_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static FILTER_ELIDE_SUBVIEWS_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static FILTER_MERGE_INTO_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+fn reset_filter_counters() {
+    use std::sync::atomic::Ordering::Relaxed;
+    DECODED_NODE_COUNT.store(0, Relaxed);
+    FILTER_KEPT_COUNT.store(0, Relaxed);
+    FILTER_ELIDE_HOIST_COUNT.store(0, Relaxed);
+    FILTER_ELIDE_SUBVIEWS_COUNT.store(0, Relaxed);
+    FILTER_MERGE_INTO_COUNT.store(0, Relaxed);
+}
+
+fn count_decoded_node() {
+    DECODED_NODE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn log_filter_summary() {
+    use std::sync::atomic::Ordering::Relaxed;
+    let decoded = DECODED_NODE_COUNT.load(Relaxed);
+    let hoisted = FILTER_ELIDE_HOIST_COUNT.load(Relaxed);
+    let elided_subviews = FILTER_ELIDE_SUBVIEWS_COUNT.load(Relaxed);
+    let merged = FILTER_MERGE_INTO_COUNT.load(Relaxed);
+    if hoisted == 0 && elided_subviews == 0 && merged == 0 {
+        return;
+    }
+    tracing::debug!(
+        decoded_nodes = decoded,
+        kept = FILTER_KEPT_COUNT.load(Relaxed),
+        elide_hoist = hoisted,
+        elide_subviews = elided_subviews,
+        merge_into = merged,
+        disabled = filter_disabled(),
+        "SwiftUI node-hiding filter summary"
+    );
 }
 
 #[cfg(all(target_vendor = "apple", feature = "uikit"))]
@@ -785,16 +1356,451 @@ mod tests {
         }]);
         let nodes = decode_json_nodes(&json).expect("should decode");
         assert_eq!(nodes.len(), 1);
+        // This fragment's own `readableType` is itself a
+        // `ModifiedContent<Base, Modifier>` — recursive unwrapping (Part A)
+        // now peels that apart into a clean base `class_name` plus a
+        // `modifiers` entry, instead of leaving the whole concatenated
+        // generic as the tag name.
         assert_eq!(
             nodes[0].class_name,
-            "ModifiedContent<_ConditionalContent<_ViewList_View, TabItemGroup.HostView>, NavigationSearchAdjustmentModifier>"
+            "_ConditionalContent<_ViewList_View, TabItemGroup.HostView>"
         );
-        assert!(nodes[0].modifiers.is_empty());
+        assert_eq!(
+            nodes[0].modifiers,
+            vec!["NavigationSearchAdjustmentModifier".to_string()]
+        );
         assert_eq!(nodes[0].children.len(), 1);
         // The child has a modifier (flags:2) property and no flags:1 view
         // type — the synthetic `<modifier: ...>` label case again.
         assert!(nodes[0].children[0]
             .class_name
             .contains("NavigationSearchAdjustmentModifier"));
+    }
+
+    // -----------------------------------------------------------------
+    // Part A — recursive ModifiedContent unwrapping + length cap.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn unwraps_a_single_level_of_modified_content() {
+        let (base, modifiers) = unwrap_modified_content(
+            "ModifiedContent<VStack<TupleView<(Text, Text)>>, _PaddingLayout>",
+        );
+        assert_eq!(base, "VStack<TupleView<(Text, Text)>>");
+        assert_eq!(modifiers, vec!["_PaddingLayout".to_string()]);
+    }
+
+    #[test]
+    fn unwraps_multiple_nested_levels_recursively() {
+        let (base, modifiers) = unwrap_modified_content(
+            "ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<ContentTransition>>, _AnimationModifier<Int>>",
+        );
+        assert_eq!(base, "Text");
+        assert_eq!(
+            modifiers,
+            vec![
+                "_AnimationModifier<Int>".to_string(),
+                "_EnvironmentKeyWritingModifier<ContentTransition>".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn non_modified_content_type_is_left_completely_alone() {
+        let (base, modifiers) = unwrap_modified_content("VStack<TupleView<(Text, Text)>>");
+        assert_eq!(base, "VStack<TupleView<(Text, Text)>>");
+        assert!(modifiers.is_empty());
+    }
+
+    #[test]
+    fn tolerates_a_module_qualified_modified_content_name() {
+        let (base, modifiers) = unwrap_modified_content(
+            "SwiftUI.ModifiedContent<SwiftUI.Text, SwiftUI._PaddingLayout>",
+        );
+        assert_eq!(base, "SwiftUI.Text");
+        assert_eq!(modifiers, vec!["SwiftUI._PaddingLayout".to_string()]);
+    }
+
+    #[test]
+    fn a_malformed_or_unrecognized_shape_is_never_force_unwrapped() {
+        // Three top-level generic args, not the two a real `ModifiedContent`
+        // always has — must be left alone rather than guessing which two to
+        // treat as (Base, Modifier).
+        let (base, modifiers) = unwrap_modified_content("ModifiedContent<A, B, C>");
+        assert_eq!(base, "ModifiedContent<A, B, C>");
+        assert!(modifiers.is_empty());
+    }
+
+    #[test]
+    fn cap_display_length_only_truncates_when_over_the_limit() {
+        assert_eq!(cap_display_length("short", 200), "short");
+        let exactly_at_limit = "a".repeat(200);
+        assert_eq!(cap_display_length(&exactly_at_limit, 200), exactly_at_limit);
+        let over_limit = "a".repeat(250);
+        let capped = cap_display_length(&over_limit, 200);
+        assert_eq!(capped.chars().count(), 201); // 200 chars + the "…" marker
+        assert!(capped.ends_with('…'));
+    }
+
+    /// The actual 3018-character `readableType` captured live from this
+    /// demo app's own `TabHostingController` hosting view (iOS 26.2
+    /// simulator, `SWIFTUI_DEBUG_DUMP_DIR`) — not a synthetic
+    /// approximation. Confirms the real worst-case node this pass was
+    /// built to fix: recursive unwrapping alone still leaves a huge base
+    /// (`NavigationStackStyledCore<...>`, itself wrapping a whole `VStack`
+    /// tree), so the hard length cap is what actually keeps the tag name
+    /// short here, not the unwrapping alone.
+    const REAL_WORST_CASE_READABLE_TYPE: &str = "ModifiedContent<ModifiedContent<NavigationStackStyledCore<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<VStack<TupleView<(ConnectionBadge, Spacer, Text, ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<ContentTransition>>, _AnimationModifier<Int>>, ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<Optional<Text.Case>>>, _EnvironmentKeyWritingModifier<CGFloat>>, HStack<TupleView<(CounterButton, CounterButton, CounterButton)>>, Spacer, Optional<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<HStack<TupleView<(Image, Text)>>, _EnvironmentKeyWritingModifier<Optional<Font>>>, _ForegroundStyleModifier<HierarchicalShapeStyle>>, _PaddingLayout>, _PaddingLayout>, _InsettableBackgroundShapeModifier<Material, Capsule>>>)>>, _PaddingLayout>, TransactionalPreferenceTransformModifier<NavigationTitleKey>>, _PreferenceTransformModifier<ToolbarKey>>, _TaskModifier>, NavigationStackRootDecoratingModifier>>, PositionedNavigationDestinationProcessor<NavigationStackReader<NavigationStackStyledCore<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<VStack<TupleView<(ConnectionBadge, Spacer, Text, ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<ContentTransition>>, _AnimationModifier<Int>>, ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<Optional<Text.Case>>>, _EnvironmentKeyWritingModifier<CGFloat>>, HStack<TupleView<(CounterButton, CounterButton, CounterButton)>>, Spacer, Optional<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<HStack<TupleView<(Image, Text)>>, _EnvironmentKeyWritingModifier<Optional<Font>>>, _ForegroundStyleModifier<HierarchicalShapeStyle>>, _PaddingLayout>, _PaddingLayout>, _InsettableBackgroundShapeModifier<Material, Capsule>>>)>>, _PaddingLayout>, TransactionalPreferenceTransformModifier<NavigationTitleKey>>, _PreferenceTransformModifier<ToolbarKey>>, _TaskModifier>, NavigationStackRootDecoratingModifier>>, ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<VStack<TupleView<(ConnectionBadge, Spacer, Text, ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<ContentTransition>>, _AnimationModifier<Int>>, ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<Optional<Text.Case>>>, _EnvironmentKeyWritingModifier<CGFloat>>, HStack<TupleView<(CounterButton, CounterButton, CounterButton)>>, Spacer, Optional<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<ModifiedContent<HStack<TupleView<(Image, Text)>>, _EnvironmentKeyWritingModifier<Optional<Font>>>, _ForegroundStyleModifier<HierarchicalShapeStyle>>, _PaddingLayout>, _PaddingLayout>, _InsettableBackgroundShapeModifier<Material, Capsule>>>)>>, _PaddingLayout>, TransactionalPreferenceTransformModifier<NavigationTitleKey>>, _PreferenceTransformModifier<ToolbarKey>>, _TaskModifier>>.AppliedBody>>, _PreferenceTransformModifier<InspectorStorageV5.PreferenceKey>>";
+
+    #[test]
+    fn real_3018_char_worst_case_node_unwraps_and_caps_to_a_short_tag_name() {
+        assert_eq!(REAL_WORST_CASE_READABLE_TYPE.chars().count(), 3018);
+        let (base, modifiers) = unwrap_modified_content(REAL_WORST_CASE_READABLE_TYPE);
+        // Two levels of ModifiedContent peeled off the outside; the base
+        // left over (a NavigationStackStyledCore wrapping a whole VStack
+        // tree) is still huge on its own — recursive unwrapping alone does
+        // NOT fully solve this real case, which is exactly why the hard
+        // cap below exists.
+        assert_eq!(modifiers.len(), 2);
+        assert!(base.starts_with("NavigationStackStyledCore<"));
+        assert!(
+            base.chars().count() > MAX_CLASS_NAME_CHARS,
+            "this is the real case the cap exists for — expected the unwrapped base to still be huge"
+        );
+
+        let capped = cap_display_length(&base, MAX_CLASS_NAME_CHARS);
+        assert_eq!(capped.chars().count(), MAX_CLASS_NAME_CHARS + 1);
+        assert!(capped.ends_with('…'));
+
+        // End-to-end through the actual decode path, not just the two
+        // helpers in isolation.
+        let json = serde_json::json!([{
+            "properties": [
+                { "id": 0, "attribute": { "flags": 1, "readableType": REAL_WORST_CASE_READABLE_TYPE } }
+            ],
+            "children": []
+        }]);
+        let nodes = decode_json_nodes(&json).expect("should decode");
+        assert!(nodes[0].class_name.chars().count() <= MAX_CLASS_NAME_CHARS + 1);
+        assert!(nodes[0]
+            .class_name
+            .starts_with("NavigationStackStyledCore<"));
+        assert!(nodes[0].class_name.ends_with('…'));
+        assert_eq!(nodes[0].modifiers.len(), 2);
+    }
+
+    // -----------------------------------------------------------------
+    // Part B — bounded properties flattener.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn flattens_a_scalar_subattribute_into_a_row() {
+        let properties = serde_json::json!([
+            {
+                "attribute": {
+                    "type": "SwiftUI.NavigationSearchAdjustmentModifier",
+                    "readableType": "NavigationSearchAdjustmentModifier",
+                    "flags": 0,
+                    "subattributes": [
+                        {
+                            "name": "searchAdjustment",
+                            "readableType": "SearchAdjustment",
+                            "value": "disabled",
+                            "type": "SwiftUI.SearchAdjustment",
+                            "flags": 0
+                        }
+                    ]
+                }
+            }
+        ]);
+        let rows = flatten_node_properties(properties.as_array().unwrap(), 8, 50);
+        assert_eq!(
+            rows,
+            vec![("searchAdjustment".to_string(), "disabled".to_string())]
+        );
+    }
+
+    #[test]
+    fn leaf_attribute_with_no_value_falls_back_to_its_own_type_as_the_value() {
+        let properties = serde_json::json!([
+            {
+                "attribute": {
+                    "type": "SwiftUI._PaddingLayout",
+                    "readableType": "_PaddingLayout",
+                    "flags": 2
+                }
+            }
+        ]);
+        let rows = flatten_node_properties(properties.as_array().unwrap(), 8, 50);
+        assert_eq!(
+            rows,
+            vec![("_PaddingLayout".to_string(), "_PaddingLayout".to_string())]
+        );
+    }
+
+    #[test]
+    fn flattened_row_title_and_value_are_capped_like_class_name_is() {
+        // Confirmed live: a `flags:1` attribute with no `name_hint`, no
+        // scalar value, and no subattributes otherwise produces a row whose
+        // title *and* value are both its own type string verbatim — for a
+        // deeply-nested-generic SwiftUI type, that's the exact same
+        // unreadable-length problem `class_name` has, just restated as a
+        // `--swiftui-<huge>` custom property in the Styles pane instead.
+        let huge_type = format!("VStack<{}>", "Text, ".repeat(60));
+        assert!(huge_type.chars().count() > FLATTEN_ROW_TEXT_CHAR_LIMIT);
+        let properties = serde_json::json!([
+            { "attribute": { "type": huge_type.clone(), "readableType": huge_type, "flags": 1 } }
+        ]);
+        let rows = flatten_node_properties(properties.as_array().unwrap(), 8, 50);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].0.chars().count() <= FLATTEN_ROW_TEXT_CHAR_LIMIT + 1);
+        assert!(rows[0].1.chars().count() <= FLATTEN_ROW_TEXT_CHAR_LIMIT + 1);
+        assert!(rows[0].0.ends_with('…'));
+        assert!(rows[0].1.ends_with('…'));
+    }
+
+    #[test]
+    fn row_cap_truncates_and_reports_a_note() {
+        // 5 top-level properties, each a leaf with no value/subattributes.
+        let properties: Vec<serde_json::Value> = (0..5)
+            .map(|i| {
+                serde_json::json!({
+                    "attribute": {
+                        "type": format!("SwiftUI.Thing{i}"),
+                        "readableType": format!("Thing{i}"),
+                        "flags": 2
+                    }
+                })
+            })
+            .collect();
+        let rows = flatten_node_properties(&properties, 8, 2);
+        // 2 real rows (the cap) + 1 truncation-note row.
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0], ("Thing0".to_string(), "Thing0".to_string()));
+        assert_eq!(rows[1], ("Thing1".to_string(), "Thing1".to_string()));
+        assert_eq!(rows[2].0, "…");
+        assert!(rows[2].1.contains("more (truncated)"));
+    }
+
+    #[test]
+    fn depth_limit_truncates_deeply_nested_subattributes_and_reports_a_note() {
+        // Build a chain of subattributes nested 5 deep; a depth_limit of 2
+        // should stop partway through and report the cut-off.
+        fn nested(depth: usize) -> serde_json::Value {
+            if depth == 0 {
+                serde_json::json!({
+                    "name": "leaf",
+                    "type": "SwiftUI.Leaf",
+                    "readableType": "Leaf",
+                    "flags": 0,
+                    "value": "bottom"
+                })
+            } else {
+                serde_json::json!({
+                    "name": format!("level{depth}"),
+                    "type": "SwiftUI.Level",
+                    "readableType": "Level",
+                    "flags": 0,
+                    "subattributes": [nested(depth - 1)]
+                })
+            }
+        }
+        let properties = vec![serde_json::json!({ "attribute": nested(5) })];
+        let rows = flatten_node_properties(&properties, 2, 50);
+        // Row cap wasn't hit; depth limit was — still expect a truncation
+        // note, not a silent drop.
+        assert!(rows.iter().any(|(title, _)| title == "…"));
+    }
+
+    #[test]
+    fn no_truncation_note_when_nothing_was_cut_off() {
+        let properties = serde_json::json!([
+            { "attribute": { "type": "SwiftUI.Text", "readableType": "Text", "flags": 1 } }
+        ]);
+        let rows = flatten_node_properties(properties.as_array().unwrap(), 8, 50);
+        assert!(!rows.iter().any(|(title, _)| title == "…"));
+    }
+
+    // -----------------------------------------------------------------
+    // Node-hiding filter (classify / apply_view_filter).
+    // -----------------------------------------------------------------
+
+    fn node(class_name: &str, modifiers: Vec<&str>, children: Vec<ViewNode>) -> ViewNode {
+        ViewNode {
+            class_name: class_name.to_string(),
+            frame: Frame {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+            },
+            is_hidden: false,
+            alpha: 1.0,
+            tag: 0,
+            accessibility_id: None,
+            modifiers: modifiers.into_iter().map(str::to_string).collect(),
+            style_rows: Vec::new(),
+            children,
+        }
+    }
+
+    fn leaf_node(class_name: &str) -> ViewNode {
+        node(class_name, vec![], vec![])
+    }
+
+    #[test]
+    fn transparent_wrapper_with_one_child_and_no_modifiers_is_elide_hoist() {
+        let wrapper = node(
+            "_VariadicView.Tree<_VStackLayout, _VariadicView_Children>",
+            vec![],
+            vec![leaf_node("Text")],
+        );
+        assert_eq!(classify(&wrapper), FilterDecision::ElideHoist);
+    }
+
+    #[test]
+    fn transparent_wrapper_with_two_children_is_kept_not_hoisted() {
+        // Hoisting a multi-child wrapper would ambiguously reparent
+        // siblings that were never siblings in the real view tree.
+        let wrapper = node(
+            "_VariadicView.Tree<_VStackLayout, _VariadicView_Children>",
+            vec![],
+            vec![leaf_node("Text"), leaf_node("Image")],
+        );
+        assert_eq!(classify(&wrapper), FilterDecision::Keep);
+    }
+
+    #[test]
+    fn transparent_wrapper_carrying_its_own_modifier_is_kept_not_hoisted() {
+        // Eliding this would silently delete the modifier detail it
+        // carries — never allowed, regardless of child count.
+        let wrapper = node("AnyView", vec!["_PaddingLayout"], vec![leaf_node("Text")]);
+        assert_eq!(classify(&wrapper), FilterDecision::Keep);
+    }
+
+    #[test]
+    fn real_layout_container_is_never_a_hoist_candidate_even_with_one_child() {
+        // The exact case this filter must never do: a genuine content
+        // container (VStack/HStack/ZStack/...) is not "plumbing" just
+        // because it happens to have a single child in this particular
+        // screen — a user would recognize and want to see it.
+        for name in [
+            "VStack<Text>",
+            "HStack<Text>",
+            "ZStack<Text>",
+            "List<Text>",
+            "ScrollView<Text>",
+        ] {
+            let container = node(name, vec![], vec![leaf_node("Text")]);
+            assert_eq!(
+                classify(&container),
+                FilterDecision::Keep,
+                "{name} must never be hoisted"
+            );
+        }
+    }
+
+    #[test]
+    fn known_leaf_primitive_with_children_elides_its_subviews() {
+        for name in ["Color", "Spacer", "Divider", "EmptyView"] {
+            let primitive = node(name, vec![], vec![leaf_node("_InternalPlumbing")]);
+            assert_eq!(
+                classify(&primitive),
+                FilterDecision::ElideSubviews,
+                "{name} should elide its internal-plumbing children"
+            );
+        }
+    }
+
+    #[test]
+    fn leaf_primitive_name_match_is_exact_not_substring() {
+        // A real interactive control that merely starts with "Color" must
+        // never be mistaken for the bare `Color` primitive.
+        let picker = node("ColorPicker<Label>", vec![], vec![leaf_node("_Internal")]);
+        assert_eq!(classify(&picker), FilterDecision::Keep);
+    }
+
+    #[test]
+    fn leaf_primitive_with_no_children_has_nothing_to_elide() {
+        let primitive = leaf_node("Color");
+        assert_eq!(classify(&primitive), FilterDecision::Keep);
+    }
+
+    #[test]
+    fn apply_view_filter_splices_hoisted_children_into_the_parent_list() {
+        // The wrapper has exactly its one required child (a real
+        // multi-child container is never a hoist candidate — see
+        // `transparent_wrapper_with_two_children_is_kept_not_hoisted`);
+        // that single child itself has its own children, which must all
+        // still be present after hoisting.
+        let grandchild = leaf_node("Image");
+        let wrapper_child = node("Text", vec![], vec![grandchild]);
+        let wrapper = node(
+            "_VariadicView.Tree<_VStackLayout, _VariadicView_Children>",
+            vec![],
+            vec![wrapper_child],
+        );
+        let sibling = leaf_node("Button");
+        let filtered = apply_view_filter(vec![wrapper, sibling]);
+        // The wrapper itself is gone; its one real child takes its place
+        // among its siblings, still carrying its own grandchild.
+        let names: Vec<&str> = filtered.iter().map(|n| n.class_name.as_str()).collect();
+        assert_eq!(names, vec!["Text", "Button"]);
+        assert_eq!(filtered[0].children.len(), 1);
+        assert_eq!(filtered[0].children[0].class_name, "Image");
+    }
+
+    #[test]
+    fn apply_view_filter_clears_children_for_elide_subviews_but_keeps_the_node() {
+        let primitive = node("Spacer", vec![], vec![leaf_node("_InternalPlumbing")]);
+        let filtered = apply_view_filter(vec![primitive]);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].class_name, "Spacer");
+        assert!(filtered[0].children.is_empty());
+    }
+
+    #[test]
+    fn apply_view_filter_disabled_is_a_full_bypass() {
+        // Exercises the `disabled` branch directly via
+        // `apply_view_filter_with`, rather than mutating the real
+        // `SWIFTUI_DEBUG_DISABLE_NODE_FILTER` process env var — tests run
+        // concurrently by default, and a shared env var would race against
+        // every other test in this module that (indirectly, through
+        // `apply_view_filter`/`filter_disabled`) reads it.
+        let wrapper = node(
+            "_VariadicView.Tree<_VStackLayout, _VariadicView_Children>",
+            vec![],
+            vec![leaf_node("Text")],
+        );
+        let filtered = apply_view_filter_with(vec![wrapper], true);
+        // Bypassed entirely — the wrapper itself is still present, unhoisted.
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0].class_name.starts_with("_VariadicView.Tree"));
+    }
+
+    /// A real captured fragment (see `decodes_a_real_captured_fragment_with_subattributes`
+    /// above for provenance) exercised end-to-end through `decode_json_nodes`:
+    /// its child is a bare `NavigationSearchAdjustmentModifier` label with no
+    /// children of its own, so no filter decision beyond `Keep` applies —
+    /// confirms the filter doesn't disturb a payload shape already covered
+    /// by other tests.
+    #[test]
+    fn real_captured_fragment_is_unaffected_by_the_node_filter() {
+        let json = serde_json::json!([{
+            "properties": [
+                { "id": 0, "attribute": { "flags": 1, "readableType": "_ConditionalContent<_ViewList_View, TabItemGroup.HostView>" } }
+            ],
+            "children": [
+                {
+                    "properties": [
+                        { "attribute": { "type": "SwiftUI.NavigationSearchAdjustmentModifier", "readableType": "NavigationSearchAdjustmentModifier", "flags": 2 } }
+                    ],
+                    "children": []
+                }
+            ]
+        }]);
+        let nodes = decode_json_nodes(&json).expect("should decode");
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].children.len(), 1);
     }
 }

--- a/crates/remo-objc/src/swiftui_debug.rs
+++ b/crates/remo-objc/src/swiftui_debug.rs
@@ -677,10 +677,7 @@ fn cap_display_length(s: &str, max_chars: usize) -> String {
 fn unwrap_modified_content(type_str: &str) -> (String, Vec<String>) {
     let mut current = type_str.trim().to_string();
     let mut modifiers = Vec::new();
-    loop {
-        let Some((name, mut args)) = parse_outer_generic(&current) else {
-            break;
-        };
+    while let Some((name, mut args)) = parse_outer_generic(&current) {
         if !is_modified_content(name) || args.len() != 2 {
             break;
         }

--- a/crates/remo-objc/src/swiftui_debug.rs
+++ b/crates/remo-objc/src/swiftui_debug.rs
@@ -14,7 +14,20 @@
 //! `UIApplicationMain`/`@main App` starts, e.g. via the Xcode scheme's
 //! launch environment — this crate does not, and should not, try to flip
 //! that env var itself at runtime, since by the time any Remo code runs the
-//! first SwiftUI views have almost always already built). The payload
+//! first SwiftUI views have almost always already built).
+//!
+//! **Gotcha confirmed the hard way**: a scheme's `EnvironmentVariables`
+//! block (what `RemoExample.xcscheme` sets) only takes effect when Xcode
+//! itself launches the app (its own Run action, or `xcodebuild ... build
+//! test`-style actions that go through the scheme). Driving the simulator
+//! through other tooling — e.g. `xcodebuildmcp simulator build-and-run`,
+//! which installs the build product and launches it via `simctl` directly —
+//! does **not** read the scheme's env vars at all, silently. To activate
+//! this capability from that kind of tooling, launch (or relaunch) the app
+//! with the `SIMCTL_CHILD_` env-var prefix `simctl launch` itself supports,
+//! e.g.:
+//! `SIMCTL_CHILD_SWIFTUI_VIEW_DEBUG=1 xcrun simctl launch <udid> com.remo.example`.
+//! The payload
 //! format (`NSData` containing either JSON on newer OS versions or a
 //! property list on older ones) and the meaning of each node's `flags`
 //! field are themselves undocumented and reverse-engineered — see the
@@ -83,6 +96,59 @@ pub fn recording_enabled() -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// OS version allowlist
+// ---------------------------------------------------------------------------
+//
+// Deliberately an *allowlist*, not a "try it and see if it parses" — for a
+// pipeline built entirely on reverse-engineered private API, "the payload
+// decoded without an error" is not evidence it decoded *correctly*. The
+// dangerous failure mode here isn't a hard parse failure (that's visible:
+// an empty subtree, a debug log). It's the OS changing `flags` semantics or
+// the payload shape *just* enough that decoding still succeeds but produces
+// a plausible-looking, semantically wrong tree — silently misleading data
+// in a debugging tool, which is worse than the tool visibly not working.
+// Getting this pipeline working at all took two real crash/correctness
+// fixes discovered only by running it for real (an objc2 type-encoding
+// panic on `-bytes`, a serde_json recursion-limit failure, and the true
+// `attribute`-nested JSON schema — none of that was predictable from the
+// original write-up alone). That history is exactly why "parses" isn't
+// trusted as "verified" here: every OS major version below must have
+// actually been run through the Phase-0 spike (dump the raw payload via
+// `SWIFTUI_DEBUG_DUMP_DIR`, confirm it decodes into a tree that matches the
+// real view hierarchy) before being added.
+
+/// OS major versions this module's private-API pipeline has actually been
+/// spike-verified against. Confirmed specifically on iOS 26.2 (see this
+/// module's git history); iOS 26.x in general is assumed close enough to
+/// share the same payload shape, but no other major version has been
+/// checked at all.
+const VERIFIED_MAJOR_OS_VERSIONS: &[i64] = &[26];
+
+/// Portable so it's unit-testable without objc2/a real device — see
+/// `current_os_version` (Apple-only, below) for where the actual version
+/// numbers come from.
+fn is_verified_os_version(major: i64) -> bool {
+    VERIFIED_MAJOR_OS_VERSIONS.contains(&major)
+}
+
+/// Logged at most once per process — a deep view hierarchy can contain many
+/// hosting views, and every one of them would otherwise repeat this warning
+/// for a single `DOM.getDocument` call.
+static WARNED_UNSUPPORTED_OS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn warn_unsupported_os_once(major: i64, minor: i64, patch: i64) {
+    if WARNED_UNSUPPORTED_OS.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    tracing::warn!(
+        os_version = %format!("{major}.{minor}.{patch}"),
+        "unsupported OS {major}.{minor}.{patch}, skipping SwiftUI debug capture — \
+         has this been verified with the Phase-0 spike test? see swiftui_debug.rs"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Apple target implementation
 // ---------------------------------------------------------------------------
 
@@ -92,8 +158,22 @@ mod apple {
     use objc2::rc::Retained;
     use objc2::runtime::AnyObject;
     use objc2::{msg_send, sel};
-    use objc2_foundation::NSData;
+    use objc2_foundation::{NSData, NSProcessInfo};
     use objc2_ui_kit::UIView;
+
+    /// The running process's `(major, minor, patch)` OS version, via the
+    /// fully public `NSProcessInfo.operatingSystemVersion` — the one piece
+    /// of this module that talks to a documented API, specifically so the
+    /// version gate itself can't be the thing that breaks.
+    fn current_os_version() -> (i64, i64, i64) {
+        let info = NSProcessInfo::processInfo();
+        let v = info.operatingSystemVersion();
+        (
+            v.majorVersion as i64,
+            v.minorVersion as i64,
+            v.patchVersion as i64,
+        )
+    }
 
     /// Whether `obj` is an instance of `class_name` (or a subclass) —
     /// checked at the actual runtime class, not assumed from the selector
@@ -269,6 +349,16 @@ mod apple {
         }
         let class_name = view.class().name().to_str().unwrap_or("").to_owned();
         if !is_hosting_view_class(&class_name) {
+            return Vec::new();
+        }
+        // Version gate: short-circuit before any private-API call is even
+        // attempted (not just before decoding) on an OS major version this
+        // pipeline hasn't been spike-verified against. See the module doc
+        // above `VERIFIED_MAJOR_OS_VERSIONS` for why "it might just parse
+        // fine anyway" is exactly the risk this refuses to take.
+        let (major, minor, patch) = current_os_version();
+        if !is_verified_os_version(major) {
+            warn_unsupported_os_once(major, minor, patch);
             return Vec::new();
         }
         let view_ptr: *const UIView = view;
@@ -498,6 +588,19 @@ mod tests {
     fn recording_disabled_by_default() {
         std::env::remove_var("SWIFTUI_VIEW_DEBUG");
         assert!(!recording_enabled());
+    }
+
+    #[test]
+    fn verified_os_version_allowlist_is_exact_not_a_range() {
+        // Spike-verified: iOS 26.x.
+        assert!(is_verified_os_version(26));
+        // Never checked at all — must stay gated off until someone actually
+        // re-runs the spike and extends the allowlist, not just because the
+        // major version number is adjacent to a verified one.
+        assert!(!is_verified_os_version(25));
+        assert!(!is_verified_os_version(27));
+        assert!(!is_verified_os_version(18));
+        assert!(!is_verified_os_version(0));
     }
 
     #[test]

--- a/crates/remo-objc/src/swiftui_debug.rs
+++ b/crates/remo-objc/src/swiftui_debug.rs
@@ -536,11 +536,32 @@ fn decode_json_node(value: &serde_json::Value) -> Option<ViewNode> {
     // synthetic `<modifier: ...>` label keeps the subtree intact; only a
     // node with neither a type name nor any modifiers is truly nothing to
     // show, and gets dropped.
-    let class_name = match (type_name, modifiers.is_empty()) {
-        (Some(t), true) => t,
-        (Some(t), false) => format!("{t} [{}]", modifiers.join(", ")),
-        (None, false) => format!("<modifier: {}>", modifiers.join(", ")),
-        (None, true) => return None,
+    //
+    // The view's own type name and its modifier list are kept as two
+    // separate fields (`class_name` / `modifiers`) rather than one
+    // concatenated string — SwiftUI's modifier chains are already deeply
+    // nested generics on their own, and appending them to `class_name`
+    // (which `domain_dom.rs` maps straight to the CDP `nodeName` the
+    // Elements panel displays as the tag name) produced unreadable
+    // multi-hundred-character tags. `domain_dom.rs`'s `attributes()`
+    // surfaces `modifiers` as its own CDP attribute instead.
+    let class_name = match &type_name {
+        Some(t) => t.clone(),
+        // The "only a modifier, no view type" case still needs *some*
+        // label — synthesize one from the modifier list rather than an
+        // empty tag name (and don't also duplicate it into `modifiers`,
+        // since it's standing in for the missing type name here, not
+        // describing a modifier applied *to* a named view).
+        None if !modifiers.is_empty() => format!("<modifier: {}>", modifiers.join(", ")),
+        None => return None,
+    };
+    // Only nodes that had a real view type of their own carry a separate
+    // `modifiers` list; the synthetic `<modifier: ...>` label above already
+    // encodes that same information in `class_name` for the type-less case.
+    let modifiers = if type_name.is_some() {
+        modifiers
+    } else {
+        Vec::new()
     };
 
     let children = value
@@ -561,6 +582,7 @@ fn decode_json_node(value: &serde_json::Value) -> Option<ViewNode> {
         alpha: 1.0,
         tag: 0,
         accessibility_id: None,
+        modifiers,
         children,
     })
 }
@@ -636,10 +658,15 @@ mod tests {
         }]);
         let nodes = decode_json_nodes(&json).expect("should decode");
         assert_eq!(nodes.len(), 1);
-        assert!(nodes[0].class_name.contains("VStack"));
-        assert!(nodes[0].class_name.contains("_PaddingLayout"));
+        // `class_name` is now just the view's own type — no modifier text
+        // appended, matching the CDP `nodeName` the Elements panel displays
+        // as the tag name (see `domain_dom.rs`'s `attributes()` for where
+        // `modifiers` surfaces instead).
+        assert_eq!(nodes[0].class_name, "VStack<TupleView<(Text, Text)>>");
+        assert_eq!(nodes[0].modifiers, vec!["_PaddingLayout".to_string()]);
         assert_eq!(nodes[0].children.len(), 1);
         assert_eq!(nodes[0].children[0].class_name, "Text");
+        assert!(nodes[0].children[0].modifiers.is_empty());
     }
 
     #[test]
@@ -652,7 +679,8 @@ mod tests {
             "children": []
         }]);
         let nodes = decode_json_nodes(&json).expect("should decode");
-        assert!(nodes[0].class_name.contains("<unknown modifier>"));
+        assert_eq!(nodes[0].class_name, "Text");
+        assert_eq!(nodes[0].modifiers, vec!["<unknown modifier>".to_string()]);
     }
 
     #[test]
@@ -669,6 +697,11 @@ mod tests {
         }]);
         let nodes = decode_json_nodes(&json).expect("should decode, not drop");
         assert!(nodes[0].class_name.contains("_PaddingLayout"));
+        // The synthetic `<modifier: ...>` label already carries this
+        // information in `class_name` (there's no real view type here for
+        // `modifiers` to be "applied to"), so it isn't duplicated into the
+        // separate `modifiers` field too.
+        assert!(nodes[0].modifiers.is_empty());
     }
 
     #[test]
@@ -752,10 +785,14 @@ mod tests {
         }]);
         let nodes = decode_json_nodes(&json).expect("should decode");
         assert_eq!(nodes.len(), 1);
-        assert!(nodes[0]
-            .class_name
-            .contains("NavigationSearchAdjustmentModifier"));
+        assert_eq!(
+            nodes[0].class_name,
+            "ModifiedContent<_ConditionalContent<_ViewList_View, TabItemGroup.HostView>, NavigationSearchAdjustmentModifier>"
+        );
+        assert!(nodes[0].modifiers.is_empty());
         assert_eq!(nodes[0].children.len(), 1);
+        // The child has a modifier (flags:2) property and no flags:1 view
+        // type — the synthetic `<modifier: ...>` label case again.
         assert!(nodes[0].children[0]
             .class_name
             .contains("NavigationSearchAdjustmentModifier"));

--- a/crates/remo-objc/src/swiftui_debug.rs
+++ b/crates/remo-objc/src/swiftui_debug.rs
@@ -1,0 +1,660 @@
+//! Best-effort SwiftUI subtree extraction, spliced under a `UIHostingView`
+//! (etc.) node so the Elements panel shows real SwiftUI view names
+//! (`SwiftUI.VStack`, `SwiftUI.Text`, ...) instead of stopping at the
+//! mangled hosting-view class name.
+//!
+//! # This is fundamentally different from the rest of `remo-objc`
+//!
+//! Every other module here (`user_defaults`, `filesystem`, `view_tree`
+//! itself) only calls public, documented UIKit/Foundation API. This module
+//! is the one exception: it calls a private, undocumented Objective-C
+//! selector (`makeViewDebugData` and two older fallback names) that SwiftUI
+//! only populates when the private `SWIFTUI_VIEW_DEBUG` environment
+//! variable was set *before the first SwiftUI view built* (normally: before
+//! `UIApplicationMain`/`@main App` starts, e.g. via the Xcode scheme's
+//! launch environment — this crate does not, and should not, try to flip
+//! that env var itself at runtime, since by the time any Remo code runs the
+//! first SwiftUI views have almost always already built). The payload
+//! format (`NSData` containing either JSON on newer OS versions or a
+//! property list on older ones) and the meaning of each node's `flags`
+//! field are themselves undocumented and reverse-engineered — see the
+//! module-level doc comment on [`crate::view_tree`] for where this splices
+//! in, and treat every detail here as liable to silently change or vanish
+//! on a future OS release.
+//!
+//! ## Explicit opt-in, not silently-on
+//!
+//! Every entry point below is a no-op (returns `None`, changing nothing
+//! about the existing plain-UIKit walk) unless the `SWIFTUI_VIEW_DEBUG`
+//! environment variable is actually set in the process — which nothing in
+//! Remo sets on the app's behalf. A caller who wants this must set it
+//! themselves (e.g. in their Xcode scheme's launch environment, as the
+//! bundled `RemoExample` demo app's shared scheme does, specifically to
+//! demonstrate this capability). This is the opt-in mechanism: no separate
+//! CDP-facing capability flag exists because one would arrive too late to
+//! matter (SwiftUI must already be recording by the time the first hosting
+//! view builds its content).
+//!
+//! ## Defensive-by-construction
+//!
+//! Every private-API call site below checks `respondsToSelector:` first and
+//! falls back to "produce nothing, let the caller keep showing the opaque
+//! hosting view" on any failure: selector missing, `NSData` empty, JSON
+//! parse failure, or a shape that doesn't look like what we expect. Nothing
+//! here should ever panic or crash the host app — a private API disappearing
+//! must only ever cost us the SwiftUI detail, never the rest of the Elements
+//! panel.
+
+// The payload-decoding functions below are only ever called from
+// `apple::dump_hosting_view`, which is gated on `feature = "uikit"` — but
+// they're written as plain, portable functions (not nested inside that
+// `cfg` block) specifically so `cargo test -p remo-objc` exercises the
+// actual decoding logic on any host, uikit feature or not. That leaves them
+// legitimately unreferenced in a non-uikit *non-test* build; silence dead
+// code there rather than gating the functions themselves behind `uikit` and
+// losing that portable test coverage.
+#![cfg_attr(not(feature = "uikit"), allow(dead_code))]
+
+use crate::view_tree::{Frame, ViewNode};
+
+/// Class-name substrings that mark a `UIView` as a SwiftUI hosting seam
+/// worth trying to expand. Matches the walk already done in
+/// `view_tree.rs`'s `walk_view` — this module just adds an extra step when
+/// one of these is seen, it does not change how the walk itself finds
+/// views.
+pub const HOSTING_VIEW_MARKERS: &[&str] = &[
+    "HostingView",
+    "HostingScrollView",
+    "PlatformViewHost",
+    "PlatformGroupContainer",
+];
+
+/// Whether `class_name` looks like a SwiftUI hosting seam.
+pub fn is_hosting_view_class(class_name: &str) -> bool {
+    HOSTING_VIEW_MARKERS
+        .iter()
+        .any(|marker| class_name.contains(marker))
+}
+
+/// Whether the private recorder was actually turned on for this process.
+/// Nothing in Remo sets this env var itself — see the module doc for why.
+pub fn recording_enabled() -> bool {
+    std::env::var_os("SWIFTUI_VIEW_DEBUG").is_some()
+}
+
+// ---------------------------------------------------------------------------
+// Apple target implementation
+// ---------------------------------------------------------------------------
+
+#[cfg(all(target_vendor = "apple", feature = "uikit"))]
+mod apple {
+    use super::*;
+    use objc2::rc::Retained;
+    use objc2::runtime::AnyObject;
+    use objc2::{msg_send, sel};
+    use objc2_foundation::NSData;
+    use objc2_ui_kit::UIView;
+
+    /// Whether `obj` is an instance of `class_name` (or a subclass) —
+    /// checked at the actual runtime class, not assumed from the selector
+    /// name. Every private-API return value gets this check before it is
+    /// cast to a concrete typed binding, precisely so a future OS version
+    /// returning `nil`, a different class, or nothing recognizable at all
+    /// degrades to "show the opaque hosting view" instead of a type-encoding
+    /// mismatch panic. Mirrors `user_defaults.rs`'s `is_kind_of` helper.
+    unsafe fn is_kind_of(obj: *mut AnyObject, class_name: &std::ffi::CStr) -> bool {
+        if obj.is_null() {
+            return false;
+        }
+        let Some(class) = objc2::runtime::AnyClass::get(class_name) else {
+            return false;
+        };
+        msg_send![obj, isKindOfClass: class]
+    }
+
+    /// Try each known selector name, in the order the write-up lists them
+    /// (newest/most-official-feeling first), returning the raw `NSData`
+    /// payload from whichever one the view actually responds to.
+    ///
+    /// # Safety
+    /// `view` must be a valid, live `UIView`.
+    unsafe fn call_debug_data_selector(view: &UIView) -> Option<*mut AnyObject> {
+        let obj: &AnyObject = view;
+        for selector in [
+            sel!(makeViewDebugData),
+            sel!(_viewDebugData),
+            sel!(viewDebugData),
+        ] {
+            let responds: bool = msg_send![obj, respondsToSelector: selector];
+            if !responds {
+                continue;
+            }
+            let data: *mut AnyObject = msg_send![obj, performSelector: selector];
+            if !data.is_null() {
+                return Some(data);
+            }
+        }
+        None
+    }
+
+    /// Copies an `NSData*` into an owned `Vec<u8>`.
+    ///
+    /// Goes through `objc2_foundation::NSData`'s own typed binding rather
+    /// than hand-rolled `msg_send![data, bytes]` — found the hard way
+    /// during the initial spike: the debug-data payload comes back as a
+    /// `__NSSwiftData` (a Swift-native `Data` bridged to `NSData`), and
+    /// objc2's message-send type-encoding validation panicked
+    /// (`"invalid message send to -[Foundation.__NSSwiftData bytes]:
+    /// expected return to have type code '^v', but found '*'"`) on a
+    /// manual `*const u8`-typed `bytes` call against that specific
+    /// bridged subclass. `NSData::as_bytes_unchecked` sidesteps that by
+    /// using the crate's own correctly-encoded binding instead of a
+    /// hand-guessed one.
+    ///
+    /// # Safety
+    /// `data` must be a valid `NSData*` (or null).
+    unsafe fn nsdata_to_vec(data: *mut AnyObject) -> Option<Vec<u8>> {
+        if data.is_null() {
+            return None;
+        }
+        // Verify the actual runtime class before casting to the typed
+        // `NSData` binding — the selector name promises `NSData`, but
+        // nothing stops a future OS from returning something else (or the
+        // private selector name being repurposed entirely). Bridged Swift
+        // `Data` values (`__NSSwiftData`, seen in practice on iOS 26) are
+        // still real `NSData` instances per `isKindOfClass:`, so this
+        // check accepts them without needing to special-case the bridged
+        // class name.
+        if !is_kind_of(data, c"NSData") {
+            return None;
+        }
+        let ns_data: &NSData = &*(data as *const NSData);
+        let bytes = ns_data.as_bytes_unchecked();
+        if bytes.is_empty() {
+            return None;
+        }
+        Some(bytes.to_vec())
+    }
+
+    /// Spike-only diagnostic: writes the raw payload to
+    /// `$SWIFTUI_DEBUG_DUMP_DIR/<class>.json` for offline inspection.
+    /// Gated behind an explicit second env var so it never fires outside a
+    /// deliberate investigation session; not part of the shipped behavior
+    /// this module offers a CDP client.
+    fn dump_raw_payload_for_spike(class_name: &str, bytes: &[u8]) {
+        let Some(dir) = std::env::var_os("SWIFTUI_DEBUG_DUMP_DIR") else {
+            return;
+        };
+        let safe_name: String = class_name
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect();
+        let path = std::path::Path::new(&dir).join(format!("{safe_name}.json"));
+        if let Err(e) = std::fs::write(&path, bytes) {
+            tracing::debug!(error = %e, path = %path.display(), "spike dump write failed");
+        }
+    }
+
+    /// The actual private-API round trip for one hosting view: call the
+    /// debug-data selector, copy the payload out, and decode it into
+    /// `ViewNode` children ready to splice under the hosting view's own
+    /// node. Returns `None` on any *recognized* failure at any step (missing
+    /// selector, empty/wrong-class payload, unparseable JSON) — but see
+    /// `dump_hosting_view` below for the other, unrecognized failure mode
+    /// this can't protect against on its own.
+    ///
+    /// # Safety
+    /// `view` must be a valid, live `UIView` on the main thread (matches
+    /// every other UIKit-touching function in this crate).
+    unsafe fn dump_hosting_view_inner(view: &UIView, class_name: &str) -> Option<Vec<ViewNode>> {
+        let data = call_debug_data_selector(view)?;
+        // Retain the NSData we were handed (it's a `+0` return per ObjC
+        // convention for these accessor-shaped selectors, but treat it as
+        // borrowed and explicitly retain/release around the copy rather
+        // than assume) so the copy below can't race a deallocation.
+        let retained: Option<Retained<AnyObject>> = Retained::retain(data);
+        let bytes = retained
+            .as_deref()
+            .and_then(|d| nsdata_to_vec(d as *const _ as *mut _))?;
+        if std::env::var_os("SWIFTUI_DEBUG_DUMP_DIR").is_some() {
+            dump_raw_payload_for_spike(class_name, &bytes);
+        }
+        match decode_payload(&bytes) {
+            Some(nodes) => Some(nodes),
+            None => {
+                tracing::debug!(
+                    class = %class_name,
+                    bytes = bytes.len(),
+                    "SwiftUI debug payload did not parse as JSON or plist; showing hosting view opaquely"
+                );
+                None
+            }
+        }
+    }
+
+    /// Attempts the full private-API round trip for one hosting view.
+    /// Returns an empty `Vec` (never panics) on *any* failure, so the
+    /// caller's fallback is always just "show the opaque hosting view, like
+    /// before this module existed."
+    ///
+    /// The inner logic (`dump_hosting_view_inner`) already handles every
+    /// failure mode it can *recognize* (missing selector, wrong class,
+    /// unparseable payload) by returning `None`. This wrapper additionally
+    /// catches the failure mode it *can't* recognize in advance: objc2's own
+    /// runtime type-encoding verification panicking when a private,
+    /// undocumented selector's actual Objective-C method signature doesn't
+    /// match what a `msg_send!` call assumed. This was caught for real
+    /// during this feature's initial spike — a bridged Swift `Data` object
+    /// (`__NSSwiftData`) returned by `makeViewDebugData` on iOS 26 turned
+    /// out to have a non-standard `-bytes` method encoding, and objc2
+    /// panicked rather than risk undefined behavior. `is_kind_of`/typed
+    /// bindings close that specific hole, but this is reverse-engineered,
+    /// undocumented private API surface — a *different* selector or a
+    /// future OS version can hit the same class of mismatch in a way no
+    /// amount of `respondsToSelector:`/class checking can predict in
+    /// advance. `catch_unwind` is the general-purpose safety net for
+    /// exactly that: it's caught here, still well inside Rust-called code
+    /// (this function's own caller, `walk_view`), not across the
+    /// `run_on_main_sync` GCD trampoline's `extern "C"` boundary further up
+    /// the stack — panicking *across* that boundary is what previously
+    /// produced "failed to initiate panic... aborting" instead of a
+    /// catchable unwind.
+    ///
+    /// # Safety
+    /// `view` must be a valid, live `UIView` on the main thread (matches
+    /// every other UIKit-touching function in this crate).
+    pub unsafe fn dump_hosting_view(view: &UIView) -> Vec<ViewNode> {
+        if !recording_enabled() {
+            return Vec::new();
+        }
+        let class_name = view.class().name().to_str().unwrap_or("").to_owned();
+        if !is_hosting_view_class(&class_name) {
+            return Vec::new();
+        }
+        let view_ptr: *const UIView = view;
+        let class_name_for_panic = class_name.clone();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            // SAFETY: `view_ptr` was derived from the `&UIView` this
+            // function was called with, which the caller guarantees is
+            // valid and main-thread-confined for the duration of this call.
+            dump_hosting_view_inner(&*view_ptr, &class_name_for_panic)
+        }));
+        match result {
+            Ok(Some(nodes)) => nodes,
+            Ok(None) => {
+                tracing::debug!(
+                    class = %class_name,
+                    "SwiftUI debug-data selector unavailable, empty, or unparseable; showing hosting view opaquely"
+                );
+                Vec::new()
+            }
+            Err(_) => {
+                tracing::warn!(
+                    class = %class_name,
+                    "SwiftUI debug-data extraction panicked (likely an objc2 \
+                     type-encoding mismatch against a private, undocumented \
+                     selector on this OS version); falling back to the \
+                     opaque hosting view instead of crashing"
+                );
+                Vec::new()
+            }
+        }
+    }
+}
+
+#[cfg(not(all(target_vendor = "apple", feature = "uikit")))]
+mod apple {}
+
+// ---------------------------------------------------------------------------
+// Payload decoding (portable — exercised by `cargo test` on any host)
+// ---------------------------------------------------------------------------
+
+/// Node `flags` values, per the reverse-engineered write-up this module is
+/// based on. Undocumented, may change across OS versions. `0`
+/// (geometry/environment/misc) has no named constant since every use of it
+/// below is the catch-all `_` arm rather than an explicit match — see that
+/// arm's comment.
+mod flags {
+    pub const VIEW_TYPE: i64 = 1;
+    pub const MODIFIER: i64 = 2;
+}
+
+/// Decode a `makeViewDebugData` payload (JSON on iOS 26+, property list on
+/// older OS versions) into `ViewNode`s ready to splice under the hosting
+/// view. Returns `None` on anything unrecognized rather than guessing.
+fn decode_payload(bytes: &[u8]) -> Option<Vec<ViewNode>> {
+    match parse_json_deeply_nested(bytes) {
+        Ok(json) => return decode_json_nodes(&json),
+        Err(e) => {
+            tracing::debug!(bytes = bytes.len(), error = %e, "SwiftUI debug payload JSON parse error");
+        }
+    }
+    // Older OS versions return a binary/XML property list instead of JSON.
+    // This crate has no plist dependency today and the write-up's own
+    // confirmed sample was JSON (iOS 26), so rather than add a whole extra
+    // parser for a format we cannot currently verify against, this is an
+    // explicit, documented gap: fall back to "nothing to splice", which
+    // callers already treat as "just show the opaque hosting view."
+    let head_len = bytes.len().min(64);
+    tracing::debug!(
+        bytes = bytes.len(),
+        head_hex = %bytes[..head_len].iter().map(|b| format!("{b:02x}")).collect::<String>(),
+        head_ascii = %String::from_utf8_lossy(&bytes[..head_len]),
+        "SwiftUI debug payload is not JSON (likely a pre-iOS-26 property list); \
+         plist decoding isn't implemented, falling back to the opaque hosting view"
+    );
+    None
+}
+
+/// Parses JSON that may nest well past serde_json's default 128-level
+/// recursion limit — confirmed necessary empirically: real
+/// `makeViewDebugData` payloads from the demo app on iOS 26.2 hit
+/// "recursion limit exceeded" a few tens of KB into a few-hundred-KB blob.
+/// `disable_recursion_limit()` alone would trade that error for a real
+/// stack overflow on a deep enough tree; `serde_stacker::maybe_grow` grows
+/// the actual OS thread stack as needed so deep-but-legitimate input
+/// parses instead of either failing or crashing.
+fn parse_json_deeply_nested(bytes: &[u8]) -> serde_json::Result<serde_json::Value> {
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    deserializer.disable_recursion_limit();
+    let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
+    serde::de::Deserialize::deserialize(deserializer)
+}
+
+fn decode_json_nodes(value: &serde_json::Value) -> Option<Vec<ViewNode>> {
+    let array = value.as_array()?;
+    let nodes: Vec<ViewNode> = array.iter().filter_map(decode_json_node).collect();
+    if nodes.is_empty() {
+        None
+    } else {
+        Some(nodes)
+    }
+}
+
+/// Decodes one `{"properties": [{"id": N, "attribute": {"type", "flags",
+/// "readableType"?, "value"?, "subattributes"?}}, ...], "children": [...]}`
+/// node — this exact shape (a property's `flags`/`type`/`readableType`
+/// nested *under* an `"attribute"` object, not flat on the property itself)
+/// was confirmed empirically against real payloads captured from the demo
+/// app on iOS 26.2 (`SWIFTUI_DEBUG_DUMP_DIR`, see `dump_raw_payload_for_spike`
+/// above); it is not from the original write-up's — necessarily incomplete —
+/// description alone.
+///
+/// Returns `None` only if there is truly nothing to show — no `flags:1`
+/// view-type property *and* no `flags:2` modifier property either. A node
+/// with a type name is shown with whatever modifier detail was found, and a
+/// node with only modifiers (confirmed to occur in real payloads — a bare
+/// wrapper like `NavigationSearchAdjustmentModifier` with no view type of
+/// its own) falls back to a synthetic `<modifier: ...>` label rather than
+/// being dropped, since dropping it would silently swallow its entire
+/// subtree too (see `decode_json_nodes`'s `filter_map`).
+fn decode_json_node(value: &serde_json::Value) -> Option<ViewNode> {
+    let properties = value.get("properties")?.as_array()?;
+
+    let mut type_name: Option<String> = None;
+    let mut modifiers: Vec<String> = Vec::new();
+
+    for prop in properties {
+        let Some(attribute) = prop.get("attribute") else {
+            continue;
+        };
+        let Some(flag) = attribute.get("flags").and_then(serde_json::Value::as_i64) else {
+            continue;
+        };
+        // `readableType` is the short, human-friendly form SwiftUI itself
+        // generates (e.g. `"VStack<Text>"`); `type` is the fully-qualified
+        // mangled-ish form (`"SwiftUI.VStack<SwiftUI.Text>"`). Prefer the
+        // former — it's what the write-up's examples show — falling back to
+        // the latter for any attribute that only has one of the two.
+        let text = attribute_text(attribute);
+        match flag {
+            flags::VIEW_TYPE => {
+                if let Some(t) = text {
+                    type_name = Some(t);
+                }
+            }
+            flags::MODIFIER => {
+                // "Modifier payloads are often null" under the safe env-var
+                // path — fall back to a bare `<unknown modifier>` rather
+                // than skipping the entry silently, so the count of
+                // modifiers applied is still visible even when their detail
+                // isn't.
+                modifiers.push(text.unwrap_or_else(|| "<unknown modifier>".to_string()));
+            }
+            _ => {
+                // flags:0 covers geometry/environment/misc attributes
+                // (`__C.CGSize`, `EnvironmentValues`, `LayoutComputer`, ...).
+                // No confirmed, stable field name for frame geometry was
+                // found in the payloads captured during this spike (unlike
+                // the write-up's claim that frames "come straight from the
+                // blob") — rather than guess at a shape that might silently
+                // misread unrelated data as a frame, this is left as a
+                // known gap: spliced SwiftUI nodes report a zero frame, and
+                // `DOM.getBoxModel` on them falls back accordingly (same
+                // honest-gap treatment `domain_dom.rs` already documents for
+                // window-coordinate conversion).
+            }
+        }
+    }
+
+    // Real captured payloads include nodes that carry only modifier
+    // (flags:2) properties and no flags:1 view-type entry of their own —
+    // e.g. a bare `NavigationSearchAdjustmentModifier` wrapper. Dropping
+    // those entirely (as an earlier version of this function did) silently
+    // swallowed their entire subtree, since `decode_json_nodes` filters out
+    // anything this function returns `None` for. Falling back to a
+    // synthetic `<modifier: ...>` label keeps the subtree intact; only a
+    // node with neither a type name nor any modifiers is truly nothing to
+    // show, and gets dropped.
+    let class_name = match (type_name, modifiers.is_empty()) {
+        (Some(t), true) => t,
+        (Some(t), false) => format!("{t} [{}]", modifiers.join(", ")),
+        (None, false) => format!("<modifier: {}>", modifiers.join(", ")),
+        (None, true) => return None,
+    };
+
+    let children = value
+        .get("children")
+        .and_then(serde_json::Value::as_array)
+        .map(|kids| kids.iter().filter_map(decode_json_node).collect())
+        .unwrap_or_default();
+
+    Some(ViewNode {
+        class_name,
+        frame: Frame {
+            x: 0.0,
+            y: 0.0,
+            width: 0.0,
+            height: 0.0,
+        },
+        is_hidden: false,
+        alpha: 1.0,
+        tag: 0,
+        accessibility_id: None,
+        children,
+    })
+}
+
+/// Prefers `attribute.readableType` (short, human-facing) over
+/// `attribute.type` (fully-qualified) over `attribute.value` (seen on
+/// `subattributes`-style leaf entries, e.g. `"searchAdjustment": "disabled"`).
+fn attribute_text(attribute: &serde_json::Value) -> Option<String> {
+    for key in ["readableType", "type", "value"] {
+        if let Some(s) = attribute.get(key).and_then(serde_json::Value::as_str) {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(all(target_vendor = "apple", feature = "uikit"))]
+pub use apple::dump_hosting_view;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recording_disabled_by_default() {
+        std::env::remove_var("SWIFTUI_VIEW_DEBUG");
+        assert!(!recording_enabled());
+    }
+
+    #[test]
+    fn hosting_view_markers_match_known_class_names() {
+        assert!(is_hosting_view_class(
+            "_TtCC7SwiftUI20TabHostingControllerP33_E387C3C47C0D2A0931533D8490A5A8B711HostingView"
+        ));
+        assert!(is_hosting_view_class(
+            "_TtGC7SwiftUI14_UIHostingViewGVS_15ModifiedContentVS_7AnyViewVS_12RootModifier__"
+        ));
+        assert!(!is_hosting_view_class("UILabel"));
+    }
+
+    #[test]
+    fn decodes_a_minimal_json_node() {
+        // Shape confirmed empirically against real `makeViewDebugData`
+        // payloads captured from the demo app (iOS 26.2 simulator): each
+        // property nests its `flags`/`type`/`readableType` under an
+        // `"attribute"` object, keyed by a separate `"id"`.
+        let json = serde_json::json!([{
+            "properties": [
+                { "id": 0, "attribute": { "flags": 1, "type": "SwiftUI.VStack<SwiftUI.TupleView<(SwiftUI.Text, SwiftUI.Text)>>", "readableType": "VStack<TupleView<(Text, Text)>>" } },
+                { "id": 1, "attribute": { "flags": 2, "type": "SwiftUI._PaddingLayout", "readableType": "_PaddingLayout" } }
+            ],
+            "children": [
+                {
+                    "properties": [
+                        { "id": 0, "attribute": { "flags": 1, "type": "SwiftUI.Text", "readableType": "Text" } }
+                    ],
+                    "children": []
+                }
+            ]
+        }]);
+        let nodes = decode_json_nodes(&json).expect("should decode");
+        assert_eq!(nodes.len(), 1);
+        assert!(nodes[0].class_name.contains("VStack"));
+        assert!(nodes[0].class_name.contains("_PaddingLayout"));
+        assert_eq!(nodes[0].children.len(), 1);
+        assert_eq!(nodes[0].children[0].class_name, "Text");
+    }
+
+    #[test]
+    fn null_modifier_falls_back_to_placeholder_instead_of_dropping() {
+        let json = serde_json::json!([{
+            "properties": [
+                { "id": 0, "attribute": { "flags": 1, "type": "SwiftUI.Text", "readableType": "Text" } },
+                { "id": 1, "attribute": { "flags": 2 } }
+            ],
+            "children": []
+        }]);
+        let nodes = decode_json_nodes(&json).expect("should decode");
+        assert!(nodes[0].class_name.contains("<unknown modifier>"));
+    }
+
+    #[test]
+    fn node_with_only_a_modifier_falls_back_to_a_synthetic_label_not_dropped() {
+        // Confirmed to occur in real captured payloads: a node whose only
+        // property is a modifier (flags:2), with no flags:1 view type of
+        // its own. Must not be dropped — that would silently swallow
+        // whatever subtree hangs under it.
+        let json = serde_json::json!([{
+            "properties": [
+                { "id": 0, "attribute": { "flags": 2, "type": "SwiftUI._PaddingLayout", "readableType": "_PaddingLayout" } }
+            ],
+            "children": []
+        }]);
+        let nodes = decode_json_nodes(&json).expect("should decode, not drop");
+        assert!(nodes[0].class_name.contains("_PaddingLayout"));
+    }
+
+    #[test]
+    fn node_with_no_type_and_no_modifier_is_dropped_not_shown_blank() {
+        let json = serde_json::json!([{
+            "properties": [],
+            "children": []
+        }]);
+        assert!(decode_json_nodes(&json).is_none());
+    }
+
+    #[test]
+    fn garbage_bytes_decode_to_none_not_a_panic() {
+        assert!(decode_payload(b"not json and not a plist").is_none());
+    }
+
+    #[test]
+    fn empty_bytes_decode_to_none() {
+        assert!(decode_payload(b"").is_none());
+    }
+
+    /// A real (trimmed) fragment of an actual `makeViewDebugData` payload,
+    /// captured from the `RemoExample` demo app on an iOS 26.2 simulator
+    /// during this feature's spike — not a hand-written guess at the shape.
+    /// Exercises `subattributes` (an extra nesting level found only on some
+    /// flags:0 attributes) and confirms it's ignored gracefully rather than
+    /// mis-parsed.
+    #[test]
+    fn decodes_a_real_captured_fragment_with_subattributes() {
+        let json = serde_json::json!([{
+            "properties": [
+                {
+                    "id": 1,
+                    "attribute": {
+                        "readableType": "ModifiedContent<_ConditionalContent<_ViewList_View, TabItemGroup.HostView>, NavigationSearchAdjustmentModifier>",
+                        "type": "SwiftUI.ModifiedContent<SwiftUI._ConditionalContent<SwiftUI._ViewList_View, SwiftUI.TabItemGroup.HostView>, SwiftUI.NavigationSearchAdjustmentModifier>",
+                        "flags": 0
+                    }
+                },
+                {
+                    "id": 0,
+                    "attribute": {
+                        "readableType": "ModifiedContent<_ConditionalContent<_ViewList_View, TabItemGroup.HostView>, NavigationSearchAdjustmentModifier>",
+                        "flags": 1,
+                        "type": "SwiftUI.ModifiedContent<SwiftUI._ConditionalContent<SwiftUI._ViewList_View, SwiftUI.TabItemGroup.HostView>, SwiftUI.NavigationSearchAdjustmentModifier>"
+                    }
+                }
+            ],
+            "children": [
+                {
+                    "properties": [
+                        {
+                            "attribute": {
+                                "type": "SwiftUI.NavigationSearchAdjustmentModifier",
+                                "readableType": "NavigationSearchAdjustmentModifier",
+                                "flags": 2
+                            },
+                            "id": 0
+                        },
+                        {
+                            "attribute": {
+                                "flags": 0,
+                                "type": "SwiftUI.NavigationSearchAdjustmentModifier",
+                                "readableType": "NavigationSearchAdjustmentModifier",
+                                "subattributes": [
+                                    {
+                                        "name": "searchAdjustment",
+                                        "readableType": "SearchAdjustment",
+                                        "value": "disabled",
+                                        "type": "SwiftUI.SearchAdjustment",
+                                        "flags": 0
+                                    }
+                                ]
+                            },
+                            "id": 1
+                        }
+                    ],
+                    "children": []
+                }
+            ]
+        }]);
+        let nodes = decode_json_nodes(&json).expect("should decode");
+        assert_eq!(nodes.len(), 1);
+        assert!(nodes[0]
+            .class_name
+            .contains("NavigationSearchAdjustmentModifier"));
+        assert_eq!(nodes[0].children.len(), 1);
+        assert!(nodes[0].children[0]
+            .class_name
+            .contains("NavigationSearchAdjustmentModifier"));
+    }
+}

--- a/crates/remo-objc/src/user_defaults.rs
+++ b/crates/remo-objc/src/user_defaults.rs
@@ -111,14 +111,39 @@ mod apple {
         nsstring_to_string(desc).map_or(Value::Null, Value::String)
     }
 
+    /// Releases the +1 `json_to_object` handed out for an `NSString` leaf
+    /// (see its doc comment) once the caller is done handing `obj` off to
+    /// something that took its own reference (`setObject:forKey:`/
+    /// `addObject:`). A no-op for every other case `json_to_object` can
+    /// return: `NSNumber`'s `numberWith*` factory methods and
+    /// `NSMutableArray`/`NSMutableDictionary`'s `*WithCapacity:` are
+    /// autoreleased by Cocoa convention, not a reference this code owns, so
+    /// releasing them here would be an over-release, not a balance.
+    ///
+    /// # Safety
+    /// `obj` must be null or a valid ObjC object pointer, per every other
+    /// helper in this module.
+    unsafe fn release_owned_string(obj: *mut AnyObject) {
+        if !obj.is_null() && is_kind_of(obj, c"NSString") {
+            let _: () = msg_send![obj, release];
+        }
+    }
+
     /// Converts a JSON value into a property-list ObjC object suitable for
     /// `NSUserDefaults setObject:forKey:`. `Value::Null` isn't representable
     /// (there is no "nil in a dictionary" in a property list) — callers that
     /// want to remove a key should call `delete`, not `set` with `null`.
     ///
     /// # Safety
-    /// The returned pointer is a valid, retained-by-autorelease-pool ObjC
-    /// object for the duration of the caller's use.
+    /// The returned pointer is a valid ObjC object for the duration of the
+    /// caller's use. For the `NSString` case specifically it is +1-retained,
+    /// not merely autoreleased: this function is called from plain async
+    /// Rust code with no guaranteed active `NSAutoreleasePool` on the
+    /// current thread, so relying on one would be a bet, not a guarantee.
+    /// Every call site that receives a `Value::String` result must balance
+    /// that +1 with [`release_owned_string`] once it's done with `obj`
+    /// (after handing it to `setObject:forKey:`/`addObject:`) — every
+    /// call site in this file already does.
     unsafe fn json_to_object(value: &Value) -> *mut AnyObject {
         match value {
             Value::Null => std::ptr::null_mut(),
@@ -135,9 +160,23 @@ mod apple {
                 }
             }
             Value::String(s) => {
+                // `NSString::from_str` returns a `Retained<NSString>` — a
+                // strong, Rust-owned reference. Just borrowing a raw pointer
+                // out of it (`&*ns as *const NSString as *mut AnyObject`)
+                // does *not* transfer that ownership: `ns` still drops (and
+                // releases/deallocates the string) at the end of this match
+                // arm, before this function returns, leaving the caller
+                // holding a dangling pointer into freed memory. Found via a
+                // real `SIGSEGV` in `-[NSUserDefaults setObject:forKey:]`
+                // when this path was exercised for real (not just in the
+                // synchronous, allocation-light unit tests below, where the
+                // freed memory usually wasn't reused yet — undefined
+                // behavior that happened to not crash). `into_raw` transfers
+                // the +1 retain to the returned pointer instead of relying
+                // on an autorelease pool that may not exist on whatever
+                // thread this runs on (see this function's `# Safety` doc).
                 let ns = NSString::from_str(s);
-                let obj: *mut AnyObject = &*ns as *const NSString as *mut AnyObject;
-                obj
+                objc2::rc::Retained::into_raw(ns).cast()
             }
             Value::Array(items) => {
                 let array: *mut AnyObject =
@@ -146,6 +185,7 @@ mod apple {
                     let obj = json_to_object(item);
                     if !obj.is_null() {
                         let _: () = msg_send![array, addObject: obj];
+                        release_owned_string(obj);
                     }
                 }
                 array
@@ -158,6 +198,7 @@ mod apple {
                         let key_ns = NSString::from_str(key);
                         let key_obj: *mut AnyObject = &*key_ns as *const NSString as *mut AnyObject;
                         let _: () = msg_send![dict, setObject: obj, forKey: key_obj];
+                        release_owned_string(obj);
                     }
                 }
                 dict
@@ -216,6 +257,7 @@ mod apple {
         let key_obj: *mut AnyObject = &*key_ns as *const NSString as *mut AnyObject;
         let value_obj = json_to_object(value);
         let _: () = msg_send![defaults, setObject: value_obj, forKey: key_obj];
+        release_owned_string(value_obj);
         Ok(())
     }
 

--- a/crates/remo-objc/src/view_tree.rs
+++ b/crates/remo-objc/src/view_tree.rs
@@ -24,6 +24,17 @@ pub struct ViewNode {
     /// is all of them outside that module.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub modifiers: Vec<String>,
+    /// Flattened `(title, value)` property rows — SwiftUI-only, like
+    /// `modifiers` above. Produced by `swiftui_debug.rs`'s bounded
+    /// `flatten_node_properties` (depth- and row-capped, with a trailing
+    /// truncation-note row when either limit is hit) from a node's full
+    /// decoded attribute tree, including nested `subattributes`. Consumed
+    /// by `domain_cdp`'s `domain_dom.rs`, which folds these into the
+    /// existing `CSS.getComputedStyleForNode` pseudo-CSS declarations
+    /// alongside `frame`, so Chrome's real Elements "Styles" pane shows
+    /// them for free.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub style_rows: Vec<(String, String)>,
     pub children: Vec<ViewNode>,
 }
 
@@ -111,6 +122,7 @@ mod apple {
             tag: view.tag(),
             accessibility_id,
             modifiers: Vec::new(),
+            style_rows: Vec::new(),
             children,
         }
     }
@@ -140,6 +152,7 @@ mod apple {
             tag: 0,
             accessibility_id: None,
             modifiers: Vec::new(),
+            style_rows: Vec::new(),
             children: vec![],
         })
     }

--- a/crates/remo-objc/src/view_tree.rs
+++ b/crates/remo-objc/src/view_tree.rs
@@ -16,6 +16,14 @@ pub struct ViewNode {
     pub tag: isize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility_id: Option<String>,
+    /// SwiftUI modifiers applied to this node (e.g. `_PaddingLayout`,
+    /// `_BackgroundModifier<Color>`), kept separate from `class_name` so the
+    /// Elements panel's tag name stays just the view's own type — see
+    /// `swiftui_debug.rs`, the only producer of a non-empty list here.
+    /// Empty (and not serialized at all) for every plain-UIKit node, which
+    /// is all of them outside that module.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modifiers: Vec<String>,
     pub children: Vec<ViewNode>,
 }
 
@@ -102,6 +110,7 @@ mod apple {
             alpha: view.alpha() as f64,
             tag: view.tag(),
             accessibility_id,
+            modifiers: Vec::new(),
             children,
         }
     }
@@ -130,6 +139,7 @@ mod apple {
             alpha: 1.0,
             tag: 0,
             accessibility_id: None,
+            modifiers: Vec::new(),
             children: vec![],
         })
     }

--- a/crates/remo-objc/src/view_tree.rs
+++ b/crates/remo-objc/src/view_tree.rs
@@ -75,6 +75,21 @@ mod apple {
             }
         };
 
+        let mut children: Vec<ViewNode> = subviews.iter().map(|sv| walk_view(&sv)).collect();
+
+        // Best-effort: if this is a SwiftUI hosting seam and the (opt-in,
+        // never-on-by-default) private recorder is active, splice the real
+        // SwiftUI subtree in as additional children — a plain UIKit view
+        // never has anything to add here, and any failure inside this call
+        // (missing selector, unparseable payload, disabled recorder) is a
+        // silent no-op that leaves `children` exactly as the plain UIKit
+        // walk already produced it. See `swiftui_debug.rs` module doc for
+        // why this is safe to call unconditionally on every hosting-view
+        // node rather than needing its own extra gating here.
+        if crate::swiftui_debug::is_hosting_view_class(&class_name) {
+            children.extend(crate::swiftui_debug::dump_hosting_view(view));
+        }
+
         ViewNode {
             class_name,
             frame: Frame {
@@ -87,7 +102,7 @@ mod apple {
             alpha: view.alpha() as f64,
             tag: view.tag(),
             accessibility_id,
-            children: subviews.iter().map(|sv| walk_view(&sv)).collect(),
+            children,
         }
     }
 }

--- a/crates/remo-sdk/src/server.rs
+++ b/crates/remo-sdk/src/server.rs
@@ -17,6 +17,7 @@ async fn build_cdp_app(registry: CapabilityRegistry) -> axum::Router {
         dispatcher.register(Arc::new(crate::cdp_adapter::remo_domain(registry.clone())));
         dispatcher.register(Arc::new(remo_cdp::domain_page::PageDomain::new()));
         dispatcher.register(Arc::new(remo_cdp::domain_dom::DomDomain::new()));
+        dispatcher.register(Arc::new(remo_cdp::domain_storage::StorageDomain::new()));
         dispatcher
     });
     axum::Router::new()

--- a/crates/remo-sdk/src/server.rs
+++ b/crates/remo-sdk/src/server.rs
@@ -338,6 +338,114 @@ fn register_storage_debugging(registry: &CapabilityRegistry) {
         ))
     });
 
+    // Keychain has no bulk-read call and each op is real Security.framework
+    // I/O (a keychain daemon round-trip, not an in-process FFI call like
+    // NSUserDefaults) — spawn_blocking for the same reason as filesystem/
+    // sqlite above, not because of any main-thread requirement.
+    registry.register("keychain.list", |_| async move {
+        let items = tokio::task::spawn_blocking(remo_objc::list_keychain_items)
+            .await
+            .map_err(|e| crate::registry::HandlerError::Internal(e.to_string()))?
+            .map_err(crate::registry::HandlerError::Internal)?;
+        Ok(crate::registry::HandlerOutput::Json(
+            serde_json::Value::Array(items),
+        ))
+    });
+
+    registry.register("keychain.get", |params| async move {
+        let service = params
+            .get("service")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                crate::registry::HandlerError::InvalidParams("requires a string \"service\"".into())
+            })?
+            .to_string();
+        let account = params
+            .get("account")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                crate::registry::HandlerError::InvalidParams("requires a string \"account\"".into())
+            })?
+            .to_string();
+        let value = tokio::task::spawn_blocking({
+            let service = service.clone();
+            let account = account.clone();
+            move || remo_objc::get_keychain_item(&service, &account)
+        })
+        .await
+        .map_err(|e| crate::registry::HandlerError::Internal(e.to_string()))?
+        .map_err(crate::registry::HandlerError::Internal)?;
+        Ok(crate::registry::HandlerOutput::Json(
+            serde_json::json!({ "service": service, "account": account, "value": value }),
+        ))
+    });
+
+    registry.register("keychain.set", |params| async move {
+        let service = params
+            .get("service")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                crate::registry::HandlerError::InvalidParams("requires a string \"service\"".into())
+            })?
+            .to_string();
+        let account = params
+            .get("account")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                crate::registry::HandlerError::InvalidParams("requires a string \"account\"".into())
+            })?
+            .to_string();
+        let password = params
+            .get("password")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                crate::registry::HandlerError::InvalidParams(
+                    "requires a string \"password\"".into(),
+                )
+            })?
+            .to_string();
+        tokio::task::spawn_blocking({
+            let service = service.clone();
+            let account = account.clone();
+            let password = password.clone();
+            move || remo_objc::set_keychain_item(&service, &account, &password)
+        })
+        .await
+        .map_err(|e| crate::registry::HandlerError::Internal(e.to_string()))?
+        .map_err(crate::registry::HandlerError::Internal)?;
+        Ok(crate::registry::HandlerOutput::Json(
+            serde_json::json!({ "service": service, "account": account }),
+        ))
+    });
+
+    registry.register("keychain.delete", |params| async move {
+        let service = params
+            .get("service")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                crate::registry::HandlerError::InvalidParams("requires a string \"service\"".into())
+            })?
+            .to_string();
+        let account = params
+            .get("account")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                crate::registry::HandlerError::InvalidParams("requires a string \"account\"".into())
+            })?
+            .to_string();
+        tokio::task::spawn_blocking({
+            let service = service.clone();
+            let account = account.clone();
+            move || remo_objc::delete_keychain_item(&service, &account)
+        })
+        .await
+        .map_err(|e| crate::registry::HandlerError::Internal(e.to_string()))?
+        .map_err(crate::registry::HandlerError::Internal)?;
+        Ok(crate::registry::HandlerOutput::Json(
+            serde_json::json!({ "service": service, "account": account, "deleted": true }),
+        ))
+    });
+
     registry.register("sqlite.query", |params| async move {
         let path = params
             .get("path")

--- a/examples/ios/RemoExample.xcodeproj/xcshareddata/xcschemes/RemoExample.xcscheme
+++ b/examples/ios/RemoExample.xcodeproj/xcshareddata/xcschemes/RemoExample.xcscheme
@@ -70,6 +70,21 @@
             ReferencedContainer = "container:RemoExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <!--
+           Opt-in for remo-objc's SwiftUI view-tree inspection spike
+           (crates/remo-objc/src/swiftui_debug.rs). Must be set before the
+           first SwiftUI view builds, which for a real app means "before
+           process launch" — the Xcode scheme's launch environment is
+           exactly that. Nothing in Remo sets this on the app's own behalf;
+           this demo app opts in deliberately to demonstrate the capability.
+         -->
+         <EnvironmentVariable
+            key = "SWIFTUI_VIEW_DEBUG"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/AppStore.swift
+++ b/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/AppStore.swift
@@ -1,3 +1,4 @@
+import SQLite3
 import SwiftUI
 
 // MARK: - Models
@@ -30,7 +31,9 @@ public final class AppStore: @unchecked Sendable {
     var showConfetti: Bool = false
     var activityLog: [LogEntry] = []
 
-    public init() {}
+    public init() {
+        seedDemoData()
+    }
 
     var accentColor: Color {
         switch accentColorName {
@@ -58,6 +61,116 @@ public final class AppStore: @unchecked Sendable {
             if activityLog.count > 200 {
                 activityLog = Array(activityLog.prefix(200))
             }
+        }
+    }
+}
+
+// MARK: - Demo data seeding
+//
+// AppStore's own state is entirely in-memory, so the generic
+// `userDefaults.list`/`filesystem.list`/`sqlite.query` capabilities have
+// nothing real to show against a fresh install. This seeds a small,
+// representative footprint in each of those three storage domains once, so
+// the capabilities have something to inspect without requiring any app
+// interaction first.
+extension AppStore {
+    fileprivate func seedDemoData() {
+        seedUserDefaults()
+        seedSandboxFiles()
+        seedSQLiteDatabase()
+    }
+
+    private func seedUserDefaults() {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: "remo.demo.hasSeeded") == nil else { return }
+        defaults.set("Guest", forKey: "username")
+        defaults.set(true, forKey: "hasCompletedOnboarding")
+        defaults.set(12, forKey: "launchCount")
+        defaults.set("blue", forKey: "preferredAccentColor")
+        defaults.set(["remo", "cdp", "swiftui"], forKey: "recentSearches")
+        defaults.set(Date().timeIntervalSince1970, forKey: "lastSyncTimestamp")
+        defaults.set(true, forKey: "remo.demo.hasSeeded")
+    }
+
+    private func seedSandboxFiles() {
+        let fileManager = FileManager.default
+        guard let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return
+        }
+        let cacheDirectory = documents.appendingPathComponent("cache", isDirectory: true)
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+
+        let notes = documents.appendingPathComponent("notes.txt")
+        if !fileManager.fileExists(atPath: notes.path) {
+            try? "Remember to check the Remo demo before the review.".write(
+                to: notes, atomically: true, encoding: .utf8)
+        }
+
+        let sessionLog = documents.appendingPathComponent("session.log")
+        if !fileManager.fileExists(atPath: sessionLog.path) {
+            let lines = (1...5).map { "2026-08-02 09:0\($0):00 [info] app session tick #\($0)" }
+                .joined(separator: "\n")
+            try? lines.write(to: sessionLog, atomically: true, encoding: .utf8)
+        }
+
+        let thumbnail = cacheDirectory.appendingPathComponent("thumbnail.dat")
+        if !fileManager.fileExists(atPath: thumbnail.path) {
+            try? Data((0..<256).map { UInt8($0 & 0xFF) }).write(to: thumbnail)
+        }
+    }
+
+    private func seedSQLiteDatabase() {
+        guard
+            let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+                .first
+        else {
+            return
+        }
+        let dbURL = documents.appendingPathComponent("demo.sqlite")
+
+        var db: OpaquePointer?
+        guard sqlite3_open(dbURL.path, &db) == SQLITE_OK, let db else { return }
+        defer { sqlite3_close(db) }
+
+        sqlite3_exec(
+            db,
+            """
+            CREATE TABLE IF NOT EXISTS todos (
+                id INTEGER PRIMARY KEY,
+                title TEXT NOT NULL,
+                done INTEGER NOT NULL DEFAULT 0,
+                created_at REAL NOT NULL
+            )
+            """,
+            nil, nil, nil
+        )
+
+        var countStatement: OpaquePointer?
+        var existingRowCount: Int32 = 0
+        if sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM todos", -1, &countStatement, nil) == SQLITE_OK,
+            sqlite3_step(countStatement) == SQLITE_ROW
+        {
+            existingRowCount = sqlite3_column_int(countStatement, 0)
+        }
+        sqlite3_finalize(countStatement)
+        guard existingRowCount == 0 else { return }
+
+        let sampleTodos = ["Ship Remo demo", "Write release notes", "Review PR #42", "Update onboarding copy"]
+        for (index, title) in sampleTodos.enumerated() {
+            var insertStatement: OpaquePointer?
+            guard
+                sqlite3_prepare_v2(
+                    db, "INSERT INTO todos (title, done, created_at) VALUES (?, ?, ?)", -1,
+                    &insertStatement, nil) == SQLITE_OK
+            else { continue }
+            defer { sqlite3_finalize(insertStatement) }
+            // SQLITE_TRANSIENT tells SQLite to copy the string immediately —
+            // `title` doesn't outlive this loop iteration otherwise.
+            let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            sqlite3_bind_text(insertStatement, 1, title, -1, sqliteTransient)
+            sqlite3_bind_int(insertStatement, 2, index % 2 == 0 ? 1 : 0)
+            sqlite3_bind_double(insertStatement, 3, Date().timeIntervalSince1970)
+            sqlite3_step(insertStatement)
         }
     }
 }

--- a/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/AppStore.swift
+++ b/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/AppStore.swift
@@ -30,9 +30,13 @@ public final class AppStore: @unchecked Sendable {
     var toastMessage: String?
     var showConfetti: Bool = false
     var activityLog: [LogEntry] = []
+    var networkStatus: String = "idle"
 
     public init() {
         seedDemoData()
+        Task { [weak self] in
+            await self?.performDemoFetch()
+        }
     }
 
     var accentColor: Color {
@@ -171,6 +175,35 @@ extension AppStore {
             sqlite3_bind_int(insertStatement, 2, index % 2 == 0 ? 1 : 0)
             sqlite3_bind_double(insertStatement, 3, Date().timeIntervalSince1970)
             sqlite3_step(insertStatement)
+        }
+    }
+}
+
+// MARK: - Demo network activity
+//
+// Remo has no Network domain/capability yet — there was nothing making a
+// real HTTP request anywhere in this app to test one against in the first
+// place. This adds one real `URLSession` call (fired once at launch, and
+// repeatable from Settings) so any future network-interception work has
+// live traffic to intercept instead of an app that never talks to the
+// network at all.
+extension AppStore {
+    func performDemoFetch() async {
+        guard let url = URL(string: "https://jsonplaceholder.typicode.com/todos/1") else { return }
+        let request = URLRequest(url: url)
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let body = String(decoding: data.prefix(200), as: UTF8.self)
+            await MainActor.run {
+                networkStatus = "GET /todos/1 → \(status)"
+            }
+            log(capability: "network.demoFetch", params: url.absoluteString, result: "\(status): \(body)")
+        } catch {
+            await MainActor.run {
+                networkStatus = "GET /todos/1 → failed: \(error.localizedDescription)"
+            }
+            log(capability: "network.demoFetch", params: url.absoluteString, result: "error: \(error.localizedDescription)")
         }
     }
 }

--- a/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/SettingsPage.swift
+++ b/examples/ios/RemoExamplePackage/Sources/RemoExampleFeature/SettingsPage.swift
@@ -47,6 +47,13 @@ struct SettingsPage: View {
                     }
                 }
 
+                Section("Network") {
+                    LabeledContent("Last request", value: store.networkStatus)
+                    Button("Fetch Demo Data") {
+                        Task { await store.performDemoFetch() }
+                    }
+                }
+
                 Section("Try It") {
                     CopyableCommand(
                         label: "Toast",

--- a/skills/example-ios-feature-dev/SKILL.md
+++ b/skills/example-ios-feature-dev/SKILL.md
@@ -109,9 +109,11 @@ Run a checkpoint loop. For each state you want to verify:
    roughly 3 s before a screenshot so the capture matches the settled state.
 3. **Capture** via XcodeBuildMCP's simulator screenshot tool. Prefer it over
    `remo screenshot` when you want the lossless device-native PNG for a
-   design-review diff. For structural checks, open `chrome://inspect` (or a
-   `devtools://` URL) against the running app and use the real Elements
-   panel — there's no `remo tree` command anymore.
+   design-review diff. For structural checks, open the running app's
+   `devtools://devtools/bundled/inspector.html?ws=<addr>/devtools/page/1` with
+   `open -a "Google Chrome" "<that URL>"` (skips `chrome://inspect`'s manual
+   "Configure..." step) and use the real Elements panel — there's no
+   `remo tree` command anymore.
 4. **Read** hidden state with the read capabilities you registered
    (`<feature>.visible`, counts, selected tab) to assert non-visual
    behaviour.

--- a/skills/remo-capabilities/references/cli.md
+++ b/skills/remo-capabilities/references/cli.md
@@ -71,6 +71,26 @@ Every command takes one of these:
 
 Simulator addresses can change on each launch. Re-run `remo devices` if a saved address stops working.
 
+## Opening DevTools Directly (skip `chrome://inspect`'s manual step)
+
+`chrome://inspect` normally requires a one-time "Configure..." step to add the target's
+`host:port` before it shows up in the Remote Target list. Skip that entirely with a plain shell
+command — no browser-automation tool needed, this is just launching Chrome with a URL argument:
+
+```bash
+open -a "Google Chrome" "devtools://devtools/bundled/inspector.html?ws=<ADDRESS>/devtools/page/1"
+```
+
+- `<ADDRESS>` is the same `host:port` `remo devices`/`-a` uses (e.g. `127.0.0.1:59761`).
+- The `-a "Google Chrome"` is required — a bare `open "devtools://..."` fails with
+  `kLSApplicationNotFoundErr`, because macOS has no system-wide URL-scheme handler registered for
+  `devtools://`. Chrome only resolves the scheme when launched directly with the URL as an
+  argument, not via LaunchServices' generic scheme dispatch.
+- Every mention below of "open `chrome://inspect` or a `devtools://` URL" means this command —
+  `chrome://inspect`'s manual per-launch "Configure" step is never actually required.
+- The address changes on every simulator launch (random port), so re-run this with the fresh
+  `<ADDRESS>` each time rather than reusing an old URL.
+
 ## Setup Verification Sequence
 
 Use these commands in order:
@@ -81,9 +101,9 @@ remo call -a <ADDRESS> "__ping" '{}'
 remo screenshot -a <ADDRESS> -o /tmp/remo-verify.jpg
 ```
 
-For a structural (view hierarchy) check, there's no `remo tree` command — open `chrome://inspect`
-or a `devtools://` URL against `<ADDRESS>` and use the real Elements panel instead (see "What
-moved" below).
+For a structural (view hierarchy) check, there's no `remo tree` command — open the `devtools://`
+URL above (or `chrome://inspect`) against `<ADDRESS>` and use the real Elements panel instead (see
+"What moved" below).
 
 ## Command Notes
 
@@ -143,7 +163,8 @@ These built-in capabilities are always available (invoke with `remo call`, or th
 
 ## Calling capabilities from the real Console panel (no CLI needed)
 
-Any Remo target's real Chrome DevTools Console (`chrome://inspect`/a `devtools://` URL) can call
+Any Remo target's real Chrome DevTools Console (open via the `devtools://` command above, or
+`chrome://inspect`) can call
 `Remo.invoke` directly — no `remo call`, no CLI at all. Type `remo` alone to see a self-describing
 preview of every registered capability (grouped by namespace, e.g. `{grid: {…}, ping: ƒ}`); a
 capability's own dots become real object nesting, so `grid.tab.select` is called as

--- a/skills/remo-design-review/references/cli.md
+++ b/skills/remo-design-review/references/cli.md
@@ -71,6 +71,26 @@ Every command takes one of these:
 
 Simulator addresses can change on each launch. Re-run `remo devices` if a saved address stops working.
 
+## Opening DevTools Directly (skip `chrome://inspect`'s manual step)
+
+`chrome://inspect` normally requires a one-time "Configure..." step to add the target's
+`host:port` before it shows up in the Remote Target list. Skip that entirely with a plain shell
+command — no browser-automation tool needed, this is just launching Chrome with a URL argument:
+
+```bash
+open -a "Google Chrome" "devtools://devtools/bundled/inspector.html?ws=<ADDRESS>/devtools/page/1"
+```
+
+- `<ADDRESS>` is the same `host:port` `remo devices`/`-a` uses (e.g. `127.0.0.1:59761`).
+- The `-a "Google Chrome"` is required — a bare `open "devtools://..."` fails with
+  `kLSApplicationNotFoundErr`, because macOS has no system-wide URL-scheme handler registered for
+  `devtools://`. Chrome only resolves the scheme when launched directly with the URL as an
+  argument, not via LaunchServices' generic scheme dispatch.
+- Every mention below of "open `chrome://inspect` or a `devtools://` URL" means this command —
+  `chrome://inspect`'s manual per-launch "Configure" step is never actually required.
+- The address changes on every simulator launch (random port), so re-run this with the fresh
+  `<ADDRESS>` each time rather than reusing an old URL.
+
 ## Setup Verification Sequence
 
 Use these commands in order:
@@ -81,9 +101,9 @@ remo call -a <ADDRESS> "__ping" '{}'
 remo screenshot -a <ADDRESS> -o /tmp/remo-verify.jpg
 ```
 
-For a structural (view hierarchy) check, there's no `remo tree` command — open `chrome://inspect`
-or a `devtools://` URL against `<ADDRESS>` and use the real Elements panel instead (see "What
-moved" below).
+For a structural (view hierarchy) check, there's no `remo tree` command — open the `devtools://`
+URL above (or `chrome://inspect`) against `<ADDRESS>` and use the real Elements panel instead (see
+"What moved" below).
 
 ## Command Notes
 
@@ -143,7 +163,8 @@ These built-in capabilities are always available (invoke with `remo call`, or th
 
 ## Calling capabilities from the real Console panel (no CLI needed)
 
-Any Remo target's real Chrome DevTools Console (`chrome://inspect`/a `devtools://` URL) can call
+Any Remo target's real Chrome DevTools Console (open via the `devtools://` command above, or
+`chrome://inspect`) can call
 `Remo.invoke` directly — no `remo call`, no CLI at all. Type `remo` alone to see a self-describing
 preview of every registered capability (grouped by namespace, e.g. `{grid: {…}, ping: ƒ}`); a
 capability's own dots become real object nesting, so `grid.tab.select` is called as

--- a/skills/remo-setup/SKILL.md
+++ b/skills/remo-setup/SKILL.md
@@ -42,10 +42,17 @@ land at `.remo/bin/remo`. Use the install and verification commands from `refere
 resolve the binary in this order: `.remo/bin/remo`, then `remo`. If neither exists, stop and
 complete the install first.
 
-If DevTools is chosen: skip the install entirely. Confirm your browser-automation tool can open
-`devtools://devtools/bundled/inspector.html?ws=<addr>/devtools/page/1` once the app is running
-(Step 4 covers getting `<addr>`), and use the Console's `remo.invoke(...)`/bare `remo` for every
-verification step below that would otherwise use a `remo` command.
+If DevTools is chosen: skip the install entirely. Open it directly once the app is running (Step 4
+covers getting `<addr>`) — no browser-automation tool needed, this is a plain shell command:
+
+```bash
+open -a "Google Chrome" "devtools://devtools/bundled/inspector.html?ws=<addr>/devtools/page/1"
+```
+
+This skips `chrome://inspect`'s manual "Configure..." step entirely (see `references/cli.md`'s
+"Opening DevTools Directly" section for why `-a "Google Chrome"` is required). Then use the
+Console's `remo.invoke(...)`/bare `remo` for every verification step below that would otherwise
+use a `remo` command.
 
 ## Step 2: Add the SDK
 
@@ -152,7 +159,8 @@ The setup is complete when all of the following are true:
 - screenshot capture works
 - the Elements panel renders the app's real view hierarchy
 - if the CLI was chosen: the binary resolves correctly and the app appears in `remo devices`
-- if DevTools was chosen: `devtools://...` connects and `Remo.invoke` is reachable from the Console
+- if DevTools was chosen: the `open -a "Google Chrome" "devtools://..."` command connects and
+  `Remo.invoke` is reachable from the Console
 
 After that, switch to `remo` (or DevTools) for verification work and `remo-capabilities` for
 project-specific capabilities.

--- a/skills/remo-setup/references/cli.md
+++ b/skills/remo-setup/references/cli.md
@@ -71,6 +71,26 @@ Every command takes one of these:
 
 Simulator addresses can change on each launch. Re-run `remo devices` if a saved address stops working.
 
+## Opening DevTools Directly (skip `chrome://inspect`'s manual step)
+
+`chrome://inspect` normally requires a one-time "Configure..." step to add the target's
+`host:port` before it shows up in the Remote Target list. Skip that entirely with a plain shell
+command — no browser-automation tool needed, this is just launching Chrome with a URL argument:
+
+```bash
+open -a "Google Chrome" "devtools://devtools/bundled/inspector.html?ws=<ADDRESS>/devtools/page/1"
+```
+
+- `<ADDRESS>` is the same `host:port` `remo devices`/`-a` uses (e.g. `127.0.0.1:59761`).
+- The `-a "Google Chrome"` is required — a bare `open "devtools://..."` fails with
+  `kLSApplicationNotFoundErr`, because macOS has no system-wide URL-scheme handler registered for
+  `devtools://`. Chrome only resolves the scheme when launched directly with the URL as an
+  argument, not via LaunchServices' generic scheme dispatch.
+- Every mention below of "open `chrome://inspect` or a `devtools://` URL" means this command —
+  `chrome://inspect`'s manual per-launch "Configure" step is never actually required.
+- The address changes on every simulator launch (random port), so re-run this with the fresh
+  `<ADDRESS>` each time rather than reusing an old URL.
+
 ## Setup Verification Sequence
 
 Use these commands in order:
@@ -81,9 +101,9 @@ remo call -a <ADDRESS> "__ping" '{}'
 remo screenshot -a <ADDRESS> -o /tmp/remo-verify.jpg
 ```
 
-For a structural (view hierarchy) check, there's no `remo tree` command — open `chrome://inspect`
-or a `devtools://` URL against `<ADDRESS>` and use the real Elements panel instead (see "What
-moved" below).
+For a structural (view hierarchy) check, there's no `remo tree` command — open the `devtools://`
+URL above (or `chrome://inspect`) against `<ADDRESS>` and use the real Elements panel instead (see
+"What moved" below).
 
 ## Command Notes
 
@@ -143,7 +163,8 @@ These built-in capabilities are always available (invoke with `remo call`, or th
 
 ## Calling capabilities from the real Console panel (no CLI needed)
 
-Any Remo target's real Chrome DevTools Console (`chrome://inspect`/a `devtools://` URL) can call
+Any Remo target's real Chrome DevTools Console (open via the `devtools://` command above, or
+`chrome://inspect`) can call
 `Remo.invoke` directly — no `remo call`, no CLI at all. Type `remo` alone to see a self-describing
 preview of every registered capability (grouped by namespace, e.g. `{grid: {…}, ping: ƒ}`); a
 capability's own dots become real object nesting, so `grid.tab.select` is called as

--- a/skills/remo/SKILL.md
+++ b/skills/remo/SKILL.md
@@ -56,8 +56,10 @@ Before making changes, capture the current screen and any supporting state that 
 Typical baseline evidence:
 
 - screenshot
-- the Elements panel's view hierarchy (`chrome://inspect`/a `devtools://` URL — there's no
-  `remo tree` command; this is real CDP `DOM.getDocument`)
+- the Elements panel's view hierarchy — open with
+  `open -a "Google Chrome" "devtools://devtools/bundled/inspector.html?ws=<addr>/devtools/page/1"`
+  (see `references/cli.md`'s "Opening DevTools Directly" — no `chrome://inspect` manual config
+  step needed); there's no `remo tree` command, this is real CDP `DOM.getDocument`
 - capability output for relevant internal state
 
 Add a short observation describing what is wrong or what you expect to change.

--- a/skills/remo/references/cli.md
+++ b/skills/remo/references/cli.md
@@ -71,6 +71,26 @@ Every command takes one of these:
 
 Simulator addresses can change on each launch. Re-run `remo devices` if a saved address stops working.
 
+## Opening DevTools Directly (skip `chrome://inspect`'s manual step)
+
+`chrome://inspect` normally requires a one-time "Configure..." step to add the target's
+`host:port` before it shows up in the Remote Target list. Skip that entirely with a plain shell
+command — no browser-automation tool needed, this is just launching Chrome with a URL argument:
+
+```bash
+open -a "Google Chrome" "devtools://devtools/bundled/inspector.html?ws=<ADDRESS>/devtools/page/1"
+```
+
+- `<ADDRESS>` is the same `host:port` `remo devices`/`-a` uses (e.g. `127.0.0.1:59761`).
+- The `-a "Google Chrome"` is required — a bare `open "devtools://..."` fails with
+  `kLSApplicationNotFoundErr`, because macOS has no system-wide URL-scheme handler registered for
+  `devtools://`. Chrome only resolves the scheme when launched directly with the URL as an
+  argument, not via LaunchServices' generic scheme dispatch.
+- Every mention below of "open `chrome://inspect` or a `devtools://` URL" means this command —
+  `chrome://inspect`'s manual per-launch "Configure" step is never actually required.
+- The address changes on every simulator launch (random port), so re-run this with the fresh
+  `<ADDRESS>` each time rather than reusing an old URL.
+
 ## Setup Verification Sequence
 
 Use these commands in order:
@@ -81,9 +101,9 @@ remo call -a <ADDRESS> "__ping" '{}'
 remo screenshot -a <ADDRESS> -o /tmp/remo-verify.jpg
 ```
 
-For a structural (view hierarchy) check, there's no `remo tree` command — open `chrome://inspect`
-or a `devtools://` URL against `<ADDRESS>` and use the real Elements panel instead (see "What
-moved" below).
+For a structural (view hierarchy) check, there's no `remo tree` command — open the `devtools://`
+URL above (or `chrome://inspect`) against `<ADDRESS>` and use the real Elements panel instead (see
+"What moved" below).
 
 ## Command Notes
 
@@ -143,7 +163,8 @@ These built-in capabilities are always available (invoke with `remo call`, or th
 
 ## Calling capabilities from the real Console panel (no CLI needed)
 
-Any Remo target's real Chrome DevTools Console (`chrome://inspect`/a `devtools://` URL) can call
+Any Remo target's real Chrome DevTools Console (open via the `devtools://` command above, or
+`chrome://inspect`) can call
 `Remo.invoke` directly — no `remo call`, no CLI at all. Type `remo` alone to see a self-describing
 preview of every registered capability (grouped by namespace, e.g. `{grid: {…}, ping: ƒ}`); a
 capability's own dots become real object nesting, so `grid.tab.select` is called as


### PR DESCRIPTION
## Summary
- **Keychain capability** (`keychain.list/get/set/delete`) — wraps `security-framework`'s generic-password API, mirroring `userDefaults`'s shape (Apple-gated + non-Apple stub).
- **Demo app storage seeding** — `RemoExample` previously had zero real UserDefaults/filesystem/SQLite/network data; `AppStore` now seeds representative data once at launch (plus a real `URLSession` request), so the storage capabilities and any future Network work have something real to inspect.
- **Real `DOMStorage`/`Storage` CDP domain** (`crates/remo-cdp/src/domain_storage.rs`) — the Application panel's Local Storage view previously showed nothing at all (no CDP domain backed it). Now maps `NSUserDefaults`' standard domain to a `userdefaults://standard` storage bucket with real `getDOMStorageItems`/`setDOMStorageItem`/`removeDOMStorageItem`/`clear`, wired into `Page.getResourceTree`'s `childFrames` so DevTools discovers the origin. Along the way, found and fixed a real dangling-pointer crash in `user_defaults.rs`'s `json_to_object` (a `Retained<NSString>` was dropped before use — reliably crashed the app on `setDOMStorageItem`, not caught by the existing synchronous unit tests). IndexedDB/CacheStorage intentionally deferred (documented in the module).
- **Experimental SwiftUI Elements-panel support** (`crates/remo-objc/src/swiftui_debug.rs`, opt-in via `SWIFTUI_VIEW_DEBUG` env var pre-launch, gated behind a spike-verified OS-version allowlist) — splices real SwiftUI view names into the Elements panel tree instead of stopping at opaque mangled `UIHostingView` class names. Includes: private-API bridge with `catch_unwind`/`respondsToSelector`/`isKindOfClass` defensive guards throughout; recursive `ModifiedContent<Base, Modifier>` unwrapping (fixes a real 3018-char tag name down to a 200-char hard cap); a bounded/truncating properties flattener feeding `CSS.getComputedStyleForNode` as pseudo-CSS declarations; and a conservative node-hiding filter for structurally-transparent wrapper nodes (mirrors the shape of a similar mechanism found via binary analysis of a prior-art tool, independently reasoned/implemented — not ported). Explicitly experimental/opt-in given the private-API surface; inert by default and falls back to today's behavior on any unexpected shape.
- **Docs**: `devtools://` can be opened directly via a plain `open -a "Google Chrome" "devtools://..."` shell command — no browser-automation tool or manual `chrome://inspect` "Configure..." step needed. Updated the CLI reference (4 copies) and related skills.

## Test plan
- [x] `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` all clean
- [x] Live-verified against the real `RemoExample` demo app on iOS 26.2 simulators: `keychain.*`/`userDefaults.*`/`filesystem.*`/`sqlite.query` over raw CDP; `DOMStorage.getDOMStorageItems` returning real data through real Chrome DevTools; SwiftUI capture verified before/after each fix (crash repro + fix, OS-allowlist skip path, tag-name size reduction, properties truncation)